### PR TITLE
efs fixes

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -417,8 +417,10 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     val output = if (configuration.efsMntPoint.isDefined && 
                      configuration.efsMntPoint.getOrElse("").equals(disk.toString.split(" ")(1)) &&
                      ! runtimeAttributes.efsDelocalize) {
-            AwsBatchFileOutput(makeSafeAwsBatchReferenceName(womFile.value), makeSafeAwsBatchReferenceName(womFile.value), relpath, disk)
+            // name: String, s3key: String, local: Path, mount: AwsBatchVolume
+            AwsBatchFileOutput(makeSafeAwsBatchReferenceName(womFile.value), womFile.value, relpath, disk)
         } else {
+            // if efs is not enabled, OR efs delocalization IS enabled, keep the s3 path as destination.
             AwsBatchFileOutput(makeSafeAwsBatchReferenceName(womFile.value), destination, relpath, disk)
         }
     List(output)
@@ -448,7 +450,8 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
                      ! runtimeAttributes.efsDelocalize) {
                         (globDirectory, globListFile)
                      } else {
-                        (callRootPath.resolve(globDirectory).pathAsString, callRootPath.resolve(globListFile).pathAsString)
+                        // cannot resolve absolute paths : strip the leading '/'
+                        (callRootPath.resolve(globDirectory.toString.stripPrefix("/")).pathAsString, callRootPath.resolve(globListFile.toString.stripPrefix("/")).pathAsString)
                      }
     // return results
     return (

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -259,7 +259,8 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |  b=$$(( 5 * 1024 * 1024 ))
          |  chunk_size=$$(( a > b ? a : b ))
          |  echo $$chunk_size
-         }
+         |}
+         |
          |function _check_data_integrity() {
          |  local local_path=$$1
          |  local s3_path=$$2
@@ -276,7 +277,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |  s3_content_length=$$($awsCmd s3api head-object --bucket "$$bucket" --key "$$key" --query 'ContentLength') || 
          |        { echo "Attempt to get head of object failed for $$s3_path." && return 1 ; }
          |  # local
-         |  local_content_length=$$(LC_ALL=C ls -dn -- "$$local_path" | awk '{print $$5; exit}' ) || 
+         |  local_content_length=$$(LC_ALL=C ls -dnL -- "$$local_path" | awk '{print $$5; exit}' ) || 
          |        { echo "Attempt to get local content length failed for $$_local_path." && return 1; }   
          |  # compare
          |  if [[ "$$s3_content_length" -eq "$$local_content_length" ]]; then
@@ -303,10 +304,12 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
 
     //generate a series of s3 commands to delocalize artifacts from the container to storage at the end of the task
     val outputCopyCommand = outputs.map {
+      // local is relative path, no mountpoint disk in front.
       case output: AwsBatchFileOutput if output.local.pathAsString.contains("*") => "" //filter out globs
-      case output: AwsBatchFileOutput if output.name.endsWith(".list") && output.name.contains("glob-") =>
-        Log.debug("Globbing : check for EFS settings.")
+      case output: AwsBatchFileOutput if output.s3key.endsWith(".list") && output.s3key.contains("glob-") =>
+        Log.debug("Globbing  : check for EFS settings.")
         val s3GlobOutDirectory = output.s3key.replace(".list", "")
+        // glob paths are not generated with 127 char limit, using generateGlobPaths(). name can be used safely 
         val globDirectory = output.name.replace(".list", "")
         /*
          * Need to process this list and de-localize each file if the list file actually exists
@@ -317,9 +320,10 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
            Log.debug("EFS glob output file detected: "+ output.s3key + s" / ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}")
            val test_cmd = if (efsDelocalize.isDefined && efsDelocalize.getOrElse(false)) {
                     Log.debug("delocalization on EFS is enabled")
+                    Log.debug(s"Delocalizing $globDirectory to $s3GlobOutDirectory\n")
                     s"""
-                        |touch ${output.name}
-                        |_s3_delocalize_with_retry ${output.name} ${output.s3key}
+                        |touch ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}
+                        |_s3_delocalize_with_retry ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} ${output.s3key}
                         |if [ -e $globDirectory ]; then _s3_delocalize_with_retry $globDirectory $s3GlobOutDirectory ; fi
                         |""".stripMargin
                 } else {
@@ -357,6 +361,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
           | """.stripMargin
         } else {
           // default delocalization command.
+          Log.debug(s"Delocalize from ${output.name} to ${output.s3key}\n")
           s"""
              |touch ${output.name}
              |_s3_delocalize_with_retry ${output.name} ${output.s3key}


### PR DESCRIPTION
- support paths with over 127 characters : 

- fix delocalization of efs-based globs : path as incorrect, integrity/size check failed due to symlinks

- 