### PR TITLE
Options to publish status only

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md
@@ -227,6 +227,7 @@ In the AWS backend those notifications can be send to **SNS Topic** or **EventBr
 #### AWS SNS
 
 1. Create an SNS topic, add the following to your `cromwell.conf` file and replace `topicArn` with the topic's ARN you just created:
+2. By default, all cromwell events will be publish to sns. Set `publishStatusOnly = true` if you only publish events that are `status` updates.
 
 ```
 services {
@@ -241,12 +242,13 @@ services {
                 }]
                 region = "us-east-1"
                 topicArn = "<topicARN>"
+                publishStatusOnly = true
             }
         }
     }
 }
 ```
-2. Add `sns:Publish` IAM policy to your Cromwell server IAM role. 
+3. Add `sns:Publish` IAM policy to your Cromwell server IAM role. 
 
 #### AWS EventBridge
 


### PR DESCRIPTION
Hi @henriqueribeiro, thanks for managing this fork specifically for AWS. 

My team has been using the SNS feature to publish cromwell events and we realized that for large workflows, the sns messages can get huge and this will cause 

```
software.amazon.awssdk.services.sns.model.InvalidParameterException: Invalid parameter: Message too long (Service: Sns, Status Code: 400, Request ID: 64fc8176-79das-5ad6-b4v0-d010acde41a)
```

I think in most cases, we might only be interested in status changes of the run and we have since started trying out only retruning status change events. 

This is a merge request that we think might be beneficial for the community and will like to hear what you think.

I think an alternative implementation is to allow users to define a list of keys (regex allowed) that the user will like cromwell to report for. Let me know what you think

This is only for sns (let me know if you will like me to implement the same for eventbridge).

P.S - the contributing guideline ask us to create an issue first. But i think because this change is small, so i created a PR instead.
