### PR TITLE
return bucket directly instead of listing and checking it

### DIFF
--- a/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileStore.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileStore.java
@@ -99,10 +99,7 @@ public class S3FileStore extends FileStore implements Comparable<S3FileStore> {
     }
 
     private Bucket getBucket(String bucketName) {
-        for (Bucket buck : getClient().listBuckets().buckets())
-            if (buck.name().equals(bucketName))
-                return buck;
-        return null;
+        return Bucket.builder().name(bucketName).build();
     }
 
     private boolean hasBucket(String bucketName) {


### PR DESCRIPTION
Hi  Henrique, 

Our team has been using your aws friendly cromwell with great success.

We have been using it as well for cross account bucket access. In order to do so, we had to patch a small snippet in s3fs where we replace `getClient().listBuckets().buckets()` which only list buckets you own with `Bucket.builder().name(bucketName).build();` We didnt see any need to ensure that the bucket is own by owner.

We also think that in line [Line 106](https://github.com/xquek/cromwell/blob/e0f6e19db5d15a171c7e7ba15f2024fce9682d01/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileStore.java#L106) There are some comment on how the original getBucket was limited to only buckets that you are the owner and hasBucket was implemented instead.

We were wondering if this will be something that we could add as part of your fork and if you see any value with it. Also do let us know if you need us to include more comments about the change.

Thank you!

