### PR TITLE
Fix aws unit tests

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -117,7 +117,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
     */
   lazy val reconfiguredScript: String = {
     //this is the location of the aws cli mounted into the container by the ec2 launch template
-    val awsCmd = "/usr/local/aws-cli/v2/current/bin/aws "
+    val awsCmd = "/usr/local/aws-cli/v2/current/bin/aws"
     //internal to the container, therefore not mounted
     val workDir = "/tmp/scratch"
     //working in a mount will cause collisions in long running workers
@@ -125,7 +125,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
     val insertionPoint = replaced.indexOf("\n", replaced.indexOf("#!")) +1 //just after the new line after the shebang!
     // load the config
     val conf : Config = ConfigFactory.load();
-    
+
     /* generate a series of s3 copy statements to copy any s3 files into the container. */
     val inputCopyCommand = inputs.map {
       case input: AwsBatchFileInput if input.s3key.startsWith("s3://") && input.s3key.endsWith(".tmp") =>
@@ -135,14 +135,11 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
            |sed -i 's#${AwsBatchWorkingDisk.MountPoint.pathAsString}#$workDir#g' $workDir/${input.local}
            |""".stripMargin
 
-      
       case input: AwsBatchFileInput if input.s3key.startsWith("s3://") => 
         // regular s3 objects : download to working dir.
         s"_s3_localize_with_retry ${input.s3key} ${input.mount.mountPoint.pathAsString}/${input.local}"
           .replace(AwsBatchWorkingDisk.MountPoint.pathAsString, workDir)
 
-      
-       
       case input: AwsBatchFileInput if efsMntPoint.isDefined && input.s3key.startsWith(efsMntPoint.get) =>  
         // EFS located file : test for presence on provided path.
         Log.debug("EFS input file detected: "+ input.s3key + " / "+ input.local.pathAsString)
@@ -187,11 +184,11 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |      echo "$$s3_path is not an S3 path with a bucket and key. aborting"
          |      exit 1
          |    fi
-         |    # copy  
+         |    # copy
          |    $awsCmd s3 cp --no-progress "$$s3_path" "$$destination"  ||
          |        { echo "attempt $$i to copy $$s3_path failed" && sleep $$((7 * "$$i")) && continue; }
          |    # check data integrity
-         |    _check_data_integrity $$destination $$s3_path || 
+         |    _check_data_integrity $$destination $$s3_path ||
          |       { echo "data content length difference detected in attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
          |    # copy succeeded
          |    break
@@ -207,7 +204,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |  # get the multipart chunk size
          |  chunk_size=$$(_get_multipart_chunk_size $$local_path)
          |  local MP_THRESHOLD=${mp_threshold}
-         |  # then set them 
+         |  # then set them
          |  $awsCmd configure set default.s3.multipart_threshold $$MP_THRESHOLD
          |  $awsCmd configure set default.s3.multipart_chunksize $$chunk_size
          |
@@ -220,27 +217,27 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |        exit 2
          |    fi
          |    # if destination is not a bucket : abort
-         |    if ! [[ $$destination =~ s3://([^/]+)/(.+) ]]; then 
+         |    if ! [[ $$destination =~ s3://([^/]+)/(.+) ]]; then
          |     echo "$$destination is not an S3 path with a bucket and key. aborting"
          |      exit 1
          |    fi
          |    # copy ok or try again.
          |    if [[ -d "$$local_path" ]]; then
-         |       # make sure to strip the trailing / in destination 
+         |       # make sure to strip the trailing / in destination
          |       destination=$${destination%/}
          |       # glob directory. do recursive copy
-         |       $awsCmd s3 cp --no-progress $$local_path $$destination --recursive --exclude "cromwell_glob_control_file" || 
-         |         { echo "attempt $$i to copy globDir $$local_path failed" && sleep $$((7 * "$$i")) && continue; } 
+         |       $awsCmd s3 cp --no-progress $$local_path $$destination --recursive --exclude "cromwell_glob_control_file" ||
+         |         { echo "attempt $$i to copy globDir $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
          |       # check integrity for each of the files
          |       for FILE in $$(cd $$local_path ; ls | grep -v cromwell_glob_control_file); do
-         |           _check_data_integrity $$local_path/$$FILE $$destination/$$FILE || 
+         |           _check_data_integrity $$local_path/$$FILE $$destination/$$FILE ||
          |               { echo "data content length difference detected in attempt $$i to copy $$local_path/$$FILE failed" && sleep $$((7 * "$$i")) && continue 2; }
          |       done
-         |    else 
-         |      $awsCmd s3 cp --no-progress "$$local_path" "$$destination" || 
-         |         { echo "attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue; } 
+         |    else
+         |      $awsCmd s3 cp --no-progress "$$local_path" "$$destination" ||
+         |         { echo "attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
          |      # check content length for data integrity
-         |      _check_data_integrity $$local_path $$destination || 
+         |      _check_data_integrity $$local_path $$destination ||
          |         { echo "data content length difference detected in attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
          |    fi
          |    # copy succeeded
@@ -251,9 +248,9 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |function _get_multipart_chunk_size() {
          |  local file_path=$$1
          |  # file size
-         |  file_size=$$(stat --printf="%s" $$file_path) 
+         |  file_size=$$(stat --printf="%s" $$file_path)
          |  # chunk_size : you can have at most 10K parts with at least one 5MB part
-         |  # this reflects the formula in s3-copy commands of cromwell (S3FileSystemProvider.java) 
+         |  # this reflects the formula in s3-copy commands of cromwell (S3FileSystemProvider.java)
          |  #   => long partSize = Math.max((objectSize / 10000L) + 1, 5 * 1024 * 1024);
          |  a=$$(( ( file_size / 10000) + 1 ))
          |  b=$$(( 5 * 1024 * 1024 ))
@@ -264,9 +261,9 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |function _check_data_integrity() {
          |  local local_path=$$1
          |  local s3_path=$$2
-         |  
+         |
          |  # remote : use content_length
-         |  if [[ $$s3_path =~ s3://([^/]+)/(.+) ]]; then 
+         |  if [[ $$s3_path =~ s3://([^/]+)/(.+) ]]; then
          |        bucket="$${BASH_REMATCH[1]}"
          |        key="$${BASH_REMATCH[2]}"
          |  else
@@ -274,16 +271,16 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |      echo "$$s3_path is not an S3 path with a bucket and key. aborting"
          |      exit 1
          |  fi
-         |  s3_content_length=$$($awsCmd s3api head-object --bucket "$$bucket" --key "$$key" --query 'ContentLength') || 
-         |        { echo "Attempt to get head of object failed for $$s3_path." && return 1 ; }
+         |  s3_content_length=$$($awsCmd s3api head-object --bucket "$$bucket" --key "$$key" --query 'ContentLength') ||
+         |        { echo "Attempt to get head of object failed for $$s3_path." && return 1; }
          |  # local
-         |  local_content_length=$$(LC_ALL=C ls -dnL -- "$$local_path" | awk '{print $$5; exit}' ) || 
-         |        { echo "Attempt to get local content length failed for $$_local_path." && return 1; }   
+         |  local_content_length=$$(LC_ALL=C ls -dnL -- "$$local_path" | awk '{print $$5; exit}' ) ||
+         |        { echo "Attempt to get local content length failed for $$_local_path." && return 1; }
          |  # compare
          |  if [[ "$$s3_content_length" -eq "$$local_content_length" ]]; then
          |       true
          |  else
-         |       false  
+         |       false
          |  fi
          |}
          |
@@ -375,8 +372,8 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
         s"""_s3_delocalize_with_retry $workDir/${output.local.pathAsString} ${output.s3key}""".stripMargin
 
       // file(name (full path), s3key (delocalized path), local (file basename), mount (disk details))
-      // files on EFS mounts are optionally delocalized. 
-      case output: AwsBatchFileOutput if efsMntPoint.isDefined && output.mount.mountPoint.pathAsString == efsMntPoint.get =>  
+      // files on EFS mounts are optionally delocalized.
+      case output: AwsBatchFileOutput if efsMntPoint.isDefined && output.mount.mountPoint.pathAsString == efsMntPoint.get =>
         Log.debug("EFS output file detected: "+ output.s3key + s" / ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}")
         // EFS located file : test existence or delocalize.
         var test_cmd = ""
@@ -388,25 +385,25 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
             // check file for existence
             test_cmd = s"test -e ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} || (echo 'output file: ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} does not exist' && exit 1)"
         }
-        // need to make md5sum? 
+        // need to make md5sum?
         var md5_cmd = ""
         if (efsMakeMD5.isDefined && efsMakeMD5.getOrElse(false)) {
             Log.debug("Add cmd to create MD5 sibling.")
             md5_cmd = s"""
-                            |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]] ; then 
-                            |   md5sum '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' > '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || (echo 'Could not generate ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' && exit 1 ); 
+                            |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]] ; then
+                            |   md5sum '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' > '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || (echo 'Could not generate ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' && exit 1 );
                             |fi
-                            |""".stripMargin 
+                            |""".stripMargin
         } else {
             Log.debug("MD5 not enabled: "+efsMakeMD5.get.toString())
             md5_cmd = ""
-        } 
+        }
         // return combined result
         s"""
           |${test_cmd}
           |${md5_cmd}
           | """.stripMargin
-      
+
       case output: AwsBatchFileOutput =>
         //output on a different mount
         Log.debug("output data on other mount")

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
@@ -32,7 +32,6 @@
 package cromwell.backend.impl.aws
 
 import java.util.UUID
-
 import akka.actor.{ActorRef, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestDuration}
 import common.collections.EnhancedCollections._
@@ -41,7 +40,7 @@ import cromwell.backend._
 import cromwell.backend.async.{ExecutionHandle, FailedNonRetryableExecutionHandle, PendingExecutionHandle}
 import cromwell.backend.impl.aws.AwsBatchAsyncBackendJobExecutionActor.AwsBatchPendingExecutionHandle
 import cromwell.backend.impl.aws.RunStatus.UnsuccessfulRunStatus
-import cromwell.backend.impl.aws.io.AwsBatchWorkingDisk
+import cromwell.backend.impl.aws.io.{AwsBatchWorkflowPaths, AwsBatchWorkingDisk}
 import cromwell.backend.io.JobPathsSpecHelper._
 import cromwell.backend.standard.{DefaultStandardAsyncExecutionActorParams, StandardAsyncExecutionActorParams, StandardAsyncJob, StandardExpressionFunctions, StandardExpressionFunctionsParams}
 import cromwell.cloudsupport.aws.s3.S3Storage

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchCallPathsSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchCallPathsSpec.scala
@@ -33,7 +33,8 @@ package cromwell.backend.impl.aws
 
 import common.collections.EnhancedCollections._
 import cromwell.backend.BackendSpec
-import cromwell.backend.io.JobPathsSpecHelper._
+import cromwell.backend.impl.aws.io.{AwsBatchJobPaths, AwsBatchWorkflowPaths}
+import cromwell.backend.io.JobPathsSpecHelper.{EnhancedJobPaths, EnhancedCallContext}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
 import cromwell.core.Tags.AwsTest

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -34,7 +34,7 @@ package cromwell.backend.impl.aws
 import common.collections.EnhancedCollections._
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.backend.BackendSpec._
-import cromwell.backend.impl.aws.io.AwsBatchWorkingDisk
+import cromwell.backend.impl.aws.io.{AwsBatchJobPaths, AwsBatchWorkflowPaths, AwsBatchWorkingDisk}
 import cromwell.backend.validation.ContinueOnReturnCodeFlag
 import cromwell.core.path.DefaultPathBuilder
 import cromwell.core.TestKitSuite
@@ -118,6 +118,8 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       scriptS3BucketName = "script-bucket",
       awsBatchRetryAttempts = 1,
       ulimits = Vector(Map.empty[String, String]),
+      efsDelocalize = false,
+      efsMakeMD5 = false,
       fileSystem = "s3")
 
   val containerDetail: ContainerDetail = ContainerDetail.builder().exitCode(0).build()
@@ -127,21 +129,21 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
     val job = AwsBatchJob(null, runtimeAttributes, "commandLine", script,
       "/cromwell_root/hello-rc.txt", "/cromwell_root/hello-stdout.log", "/cromwell_root/hello-stderr.log",
       Seq.empty[AwsBatchInput].toSet, Seq.empty[AwsBatchFileOutput].toSet,
-      jobPaths, Seq.empty[AwsBatchParameter], None, None)
+      jobPaths, Seq.empty[AwsBatchParameter], None, None, None, None, None, None)
     job
   }
   private def generateBasicJobForLocalFS: AwsBatchJob = {
     val job = AwsBatchJob(null, runtimeAttributes.copy(fileSystem="local"), "commandLine", script,
       "/cromwell_root/hello-rc.txt", "/cromwell_root/hello-stdout.log", "/cromwell_root/hello-stderr.log",
       Seq.empty[AwsBatchInput].toSet, Seq.empty[AwsBatchFileOutput].toSet,
-      jobPaths, Seq.empty[AwsBatchParameter], None, None)
+      jobPaths, Seq.empty[AwsBatchParameter], None, None, None, None, None, None)
     job
   }
   private def generateJobWithS3InOut: AwsBatchJob = {
     val job = AwsBatchJob(null, runtimeAttributes, "commandLine", script,
       "/cromwell_root/hello-rc.txt", "/cromwell_root/hello-stdout.log", "/cromwell_root/hello-stderr.log",
       s3Inputs, s3Outputs,
-      jobPaths, Seq.empty[AwsBatchParameter], None, None)
+      jobPaths, Seq.empty[AwsBatchParameter], None, None, None, None, None, None)
     job
   }
 

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -182,107 +182,150 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
 
   it should "add s3 localize with retry function to reconfigured script" in {
     val job = generateBasicJob
-    val retryFunctionText = s"""
-                              |export AWS_METADATA_SERVICE_TIMEOUT=10
-                              |export AWS_METADATA_SERVICE_NUM_ATTEMPTS=10
-                              |
-                              |function _s3_localize_with_retry() {
-                              |  local s3_path=$$1
-                              |  # destination must be the path to a file and not just the directory you want the file in
-                              |  local destination=$$2
-                              |
-                              |  for i in {1..6};
-                              |  do
-                              |    # abort if tries are exhausted
-                              |    if [ "$$i" -eq 6 ]; then
-                              |        echo "failed to copy $$s3_path after $$(( $$i - 1 )) attempts. aborting"
-                              |        exit 2
-                              |    fi
-                              |    # check validity of source path
-                              |    if ! [[ $$s3_path =~ s3://([^/]+)/(.+) ]]; then
-                              |      echo "$$s3_path is not an S3 path with a bucket and key. aborting"
-                              |      exit 1
-                              |    fi
-                              |    # copy  
-                              |    /usr/local/aws-cli/v2/current/bin/aws s3 cp --no-progress "$$s3_path" "$$destination"  ||
-                              |        ( echo "attempt $$i to copy $$s3_path failed" sleep $$((7 * "$$i")) && continue)
-                              |    # check data integrity
-                              |    _check_data_integrity $$destination $$s3_path || 
-                              |       (echo "data content length difference detected in attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue)
-                              |    # copy succeeded
-                              |    break
-                              |  done
-                              |}
-                              |
-                              |function _s3_delocalize_with_retry() {
-                              |  local local_path=$$1
-                              |  # destination must be the path to a file and not just the directory you want the file in
-                              |  local destination=$$2
-                              |
-                              |  for i in {1..6};
-                              |  do
-                              |    # if tries exceeded : abort
-                              |    if [ "$$i" -eq 6 ]; then
-                              |        echo "failed to delocalize $$local_path after $$(( $$i - 1 )) attempts. aborting"
-                              |        exit 2
-                              |    fi
-                              |    # if destination is not a bucket : abort
-                              |    if ! [[ $$destination =~ s3://([^/]+)/(.+) ]]; then 
-                              |     echo "$$destination is not an S3 path with a bucket and key. aborting"
-                              |      exit 1
-                              |    fi
-                              |    # copy ok or try again.
-                              |    if [[ -d "$$local_path" ]]; then
-                              |       # make sure to strip the trailing / in destination 
-                              |       destination=$${destination%/}
-                              |       # glob directory. do recursive copy
-                              |       /usr/local/aws-cli/v2/current/bin/aws s3 cp --no-progress $$local_path $$destination --recursive --exclude "cromwell_glob_control_file" || 
-                              |         ( echo "attempt $$i to copy globDir $$local_path failed" && sleep $$((7 * "$$i")) && continue) 
-                              |       # check integrity for each of the files
-                              |       for FILE in $$(cd $$local_path ; ls | grep -v cromwell_glob_control_file); do
-                              |           _check_data_integrity $$local_path/$$FILE $$destination/$$FILE || 
-                              |               ( echo "data content length difference detected in attempt $$i to copy $$local_path/$$FILE failed" && sleep $$((7 * "$$i")) && continue 2)
-                              |       done
-                              |    else 
-                              |      /usr/local/aws-cli/v2/current/bin/aws s3 cp --no-progress "$$local_path" "$$destination" || 
-                              |         ( echo "attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue) 
-                              |      # check content length for data integrity
-                              |      _check_data_integrity $$local_path $$destination || 
-                              |         ( echo "data content length difference detected in attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue)
-                              |    fi
-                              |    # copy succeeded
-                              |    break
-                              |  done
-                              |}
-                              |
-                              |function _check_data_integrity() {
-                              |  local local_path=$$1
-                              |  local s3_path=$$2
-                              |  
-                              |  # remote : use content_length
-                              |  if [[ $$s3_path =~ s3://([^/]+)/(.+) ]]; then 
-                              |        bucket="$${BASH_REMATCH[1]}"
-                              |        key="$${BASH_REMATCH[2]}"
-                              |  else
-                              |      # this is already checked in the caller function
-                              |      echo "$$s3_path is not an S3 path with a bucket and key. aborting"
-                              |      exit 1
-                              |  fi
-                              |  s3_content_length=$$(/usr/local/aws-cli/v2/current/bin/aws s3api head-object --bucket "$$bucket" --key "$$key" --query 'ContentLength') || 
-                              |        ( echo "Attempt to get head of object failed for $$s3_path." && return 1 )
-                              |  # local
-                              |  local_content_length=$$(LC_ALL=C ls -dn -- "$$local_path" | awk '{print $$5; exit}' ) || 
-                              |        ( echo "Attempt to get local content length failed for $$_local_path." && return 1 )   
-                              |  # compare
-                              |  if [[ "$$s3_content_length" -eq "$$local_content_length" ]]; then
-                              |       true
-                              |  else
-                              |       false  
-                              |  fi
-                              |}
-                              |""".stripMargin
+    val retryFunctionText =
+      s"""
+          |export AWS_METADATA_SERVICE_TIMEOUT=10
+          |export AWS_METADATA_SERVICE_NUM_ATTEMPTS=10
+          |
+          |function _s3_localize_with_retry() {
+          |  local s3_path=$$1
+          |  # destination must be the path to a file and not just the directory you want the file in
+          |  local destination=$$2
+          |
+          |  for i in {1..6};
+          |  do
+          |    # abort if tries are exhausted
+          |    if [ "$$i" -eq 6 ]; then
+          |        echo "failed to copy $$s3_path after $$(( $$i - 1 )) attempts. aborting"
+          |        exit 2
+          |    fi
+          |    # check validity of source path
+          |    if ! [[ $$s3_path =~ s3://([^/]+)/(.+) ]]; then
+          |      echo "$$s3_path is not an S3 path with a bucket and key. aborting"
+          |      exit 1
+          |    fi
+          |    # copy
+          |    /usr/local/aws-cli/v2/current/bin/aws s3 cp --no-progress "$$s3_path" "$$destination"  ||
+          |        { echo "attempt $$i to copy $$s3_path failed" && sleep $$((7 * "$$i")) && continue; }
+          |    # check data integrity
+          |    _check_data_integrity $$destination $$s3_path ||
+          |       { echo "data content length difference detected in attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
+          |    # copy succeeded
+          |    break
+          |  done
+          |}""".stripMargin
 
     job.reconfiguredScript should include (retryFunctionText)
+  }
+
+  it should "s3 delocalization with retry function in reconfigured script" in {
+    val job = generateBasicJob
+    val delocalizeText = s"""
+         |
+         |function _s3_delocalize_with_retry() {
+         |  # input variables
+         |  local local_path=$$1
+         |  # destination must be the path to a file and not just the directory you want the file in
+         |  local destination=$$2
+         |
+         |  # get the multipart chunk size
+         |  chunk_size=$$(_get_multipart_chunk_size $$local_path)
+         |  local MP_THRESHOLD=5368709120
+         |  # then set them
+         |  /usr/local/aws-cli/v2/current/bin/aws configure set default.s3.multipart_threshold $$MP_THRESHOLD
+         |  /usr/local/aws-cli/v2/current/bin/aws configure set default.s3.multipart_chunksize $$chunk_size
+         |
+         |  # try & validate upload 5 times
+         |  for i in {1..6};
+         |  do
+         |    # if tries exceeded : abort
+         |    if [ "$$i" -eq 6 ]; then
+         |        echo "failed to delocalize $$local_path after $$(( $$i - 1 )) attempts. aborting"
+         |        exit 2
+         |    fi
+         |    # if destination is not a bucket : abort
+         |    if ! [[ $$destination =~ s3://([^/]+)/(.+) ]]; then
+         |     echo "$$destination is not an S3 path with a bucket and key. aborting"
+         |      exit 1
+         |    fi
+         |    # copy ok or try again.
+         |    if [[ -d "$$local_path" ]]; then
+         |       # make sure to strip the trailing / in destination
+         |       destination=$${destination%/}
+         |       # glob directory. do recursive copy
+         |       /usr/local/aws-cli/v2/current/bin/aws s3 cp --no-progress $$local_path $$destination --recursive --exclude "cromwell_glob_control_file" ||
+         |         { echo "attempt $$i to copy globDir $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
+         |       # check integrity for each of the files
+         |       for FILE in $$(cd $$local_path ; ls | grep -v cromwell_glob_control_file); do
+         |           _check_data_integrity $$local_path/$$FILE $$destination/$$FILE ||
+         |               { echo "data content length difference detected in attempt $$i to copy $$local_path/$$FILE failed" && sleep $$((7 * "$$i")) && continue 2; }
+         |       done
+         |    else
+         |      /usr/local/aws-cli/v2/current/bin/aws s3 cp --no-progress "$$local_path" "$$destination" ||
+         |         { echo "attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
+         |      # check content length for data integrity
+         |      _check_data_integrity $$local_path $$destination ||
+         |         { echo "data content length difference detected in attempt $$i to copy $$local_path failed" && sleep $$((7 * "$$i")) && continue; }
+         |    fi
+         |    # copy succeeded
+         |    break
+         |  done
+         |}""".stripMargin
+    job.reconfiguredScript should include (delocalizeText)
+  }
+
+  it should "generate check data integrity in reconfigured script" in {
+    val job = generateBasicJob
+    val checkDataIntegrityBlock =
+      s"""
+         |function _check_data_integrity() {
+         |  local local_path=$$1
+         |  local s3_path=$$2
+         |
+         |  # remote : use content_length
+         |  if [[ $$s3_path =~ s3://([^/]+)/(.+) ]]; then
+         |        bucket="$${BASH_REMATCH[1]}"
+         |        key="$${BASH_REMATCH[2]}"
+         |  else
+         |      # this is already checked in the caller function
+         |      echo "$$s3_path is not an S3 path with a bucket and key. aborting"
+         |      exit 1
+         |  fi
+         |  s3_content_length=$$(/usr/local/aws-cli/v2/current/bin/aws s3api head-object --bucket "$$bucket" --key "$$key" --query 'ContentLength') ||
+         |        { echo "Attempt to get head of object failed for $$s3_path." && return 1; }
+         |  # local
+         |  local_content_length=$$(LC_ALL=C ls -dnL -- "$$local_path" | awk '{print $$5; exit}' ) ||
+         |        { echo "Attempt to get local content length failed for $$_local_path." && return 1; }
+         |  # compare
+         |  if [[ "$$s3_content_length" -eq "$$local_content_length" ]]; then
+         |       true
+         |  else
+         |       false
+         |  fi
+         |}
+         |""".stripMargin
+    job.reconfiguredScript should include (checkDataIntegrityBlock)
+  }
+
+  it should "generate get multipart chunk size in script" in {
+    val job = generateBasicJob
+    val getMultiplePartChunkSize =
+      s"""
+         |function _get_multipart_chunk_size() {
+         |  local file_path=$$1
+         |  # file size
+         |  file_size=$$(stat --printf="%s" $$file_path)
+         |  # chunk_size : you can have at most 10K parts with at least one 5MB part
+         |  # this reflects the formula in s3-copy commands of cromwell (S3FileSystemProvider.java)
+         |  #   => long partSize = Math.max((objectSize / 10000L) + 1, 5 * 1024 * 1024);
+         |  a=$$(( ( file_size / 10000) + 1 ))
+         |  b=$$(( 5 * 1024 * 1024 ))
+         |  chunk_size=$$(( a > b ? a : b ))
+         |  echo $$chunk_size
+         |}
+         |""".stripMargin
+
+    job.reconfiguredScript should include (getMultiplePartChunkSize)
   }
 
   it should "generate postscript with output copy command in reconfigured script" in {
@@ -292,13 +335,10 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
          |{
          |set -e
          |echo '*** DELOCALIZING OUTPUTS ***'
-         |
          |_s3_delocalize_with_retry /tmp/scratch/baa s3://bucket/somewhere/baa
          |
-         |
          |if [ -f /tmp/scratch/hello-rc.txt ]; then _s3_delocalize_with_retry /tmp/scratch/hello-rc.txt ${job.jobPaths.returnCode} ; fi
-         |
-         |if [ -f /tmp/scratch/hello-stderr.log ]; then _s3_delocalize_with_retrys /tmp/scratch/hello-stderr.log ${job.jobPaths.standardPaths.error}; fi
+         |if [ -f /tmp/scratch/hello-stderr.log ]; then _s3_delocalize_with_retry /tmp/scratch/hello-stderr.log ${job.jobPaths.standardPaths.error}; fi
          |if [ -f /tmp/scratch/hello-stdout.log ]; then _s3_delocalize_with_retry /tmp/scratch/hello-stdout.log ${job.jobPaths.standardPaths.output}; fi
          |
          |echo '*** COMPLETED DELOCALIZATION ***'
@@ -310,6 +350,8 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
          |""".stripMargin
     job.reconfiguredScript should include (postscript)
   }
+
+
 
   it should "generate preamble with input copy command in reconfigured script" in {
     val job = generateJobWithS3InOut
@@ -347,7 +389,4 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
     val job = generateBasicJob
     job.rc(jobDetail) should be (0)
   }
-
-
-
 }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
@@ -66,7 +66,10 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     false,
     "my-stuff",
     1,
-    Vector(Map.empty[String, String]))
+    Vector(Map.empty[String, String]),
+    false,
+    false
+  )
 
   val expectedDefaultsLocalFS = new AwsBatchRuntimeAttributes(refineMV[Positive](1), Vector("us-east-1a", "us-east-1b"),
 
@@ -79,6 +82,8 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     "",
     1,
     Vector(Map.empty[String, String]),
+    false,
+    false,
     "local")
 
   "AwsBatchRuntimeAttributes" should {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPathsSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPathsSpec.scala
@@ -33,6 +33,7 @@ package cromwell.backend.impl.aws
 
 import common.collections.EnhancedCollections._
 import cromwell.backend.BackendSpec
+import cromwell.backend.impl.aws.io.AwsBatchWorkflowPaths
 import org.scalatest.flatspec.AnyFlatSpecLike
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
 import cromwell.core.Tags.AwsTest


### PR DESCRIPTION
Hi @henriqueribeiro and @geertvandeweyer,

Thanks for maintaining the fork. This Pull request is to update the following tests to account for recent updates:
These are changes to get the tests to compile. I also removed some trailing white spaces in `AwsBatchJob.scala` please do take a look and let me know if there is any issue! thanks

## Replacing mockito-sugar with vanilla mockito

It looks like mockito-sugar was removed as a test dependencies. Use vanilla mockito instead.

- [AmazonEcrPublicSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-5482d69173eeb200553bc051c95aae21b8f39990a09d23af6c6d1a96ab856815)
- [AmazonEcrSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-43274999f849f9b16c45c1d355859866465f4d6df8349815b43b0eba322d3eb6)

## Missing imports 

I think this might be because the package renamed from 
`cromwell.backend.impl.aws` to `cromwell.backend.impl.aws.io` for `AwsBatchJobPaths`, AwsBatchWorkflowPaths`, `AwsBatchWorkingDisk`

- [AwsBatchAsyncBackendJobExecutionActorSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-1d5366f85f2f9a85982904f9298f8332e8a0f13e20a2b0e692ded14c6bfd8c67)
- [AwsBatchAsyncBackendJobExecutionActorSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-1d5366f85f2f9a85982904f9298f8332e8a0f13e20a2b0e692ded14c6bfd8c67)
- [AwsBatchCallPathsSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-a0677fd985d2bda756e04a503c9962bc258366d0354305e336bd096a0a43dfb1)
- [AwsBatchWorkflowPathsSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-379f02ce0a7a59566bf7fa99259c6399ef3aa5ede0beb4bb75f1585d4c531b2c)

## Missing Args and imports

With the introduction of new EFS feature, there are some missing args `AwsBatchJob` and `AwsBatchRuntimeAttributes`
- [AwsBatchRuntimeAttributesSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-5e51038c6ee40df5b31e333fa67990e17283d5602ee2685630598c933dee2e0d)
- [AwsBatchJobSpec.scala](https://github.com/henriqueribeiro/cromwell/compare/develop_aws...xquek:cromwell:fix-aws-unit-tests?expand=1#diff-85c5b12d9cf9412925e5a1c11ab7572194943b64f036983be0fc3e28e452eb04)