### PR TITLE
Add evaluteOnExit for aws batch retry

### DIFF
--- a/backend/src/main/scala/cromwell/backend/backend.scala
+++ b/backend/src/main/scala/cromwell/backend/backend.scala
@@ -140,6 +140,7 @@ object CommonBackendConfigurationAttributes {
     "default-runtime-attributes.docker",
     "default-runtime-attributes.queueArn",
     "default-runtime-attributes.awsBatchRetryAttempts",
+    "default-runtime-attributes.awsBatchEvaluateOnExit",
     "default-runtime-attributes.ulimits",
     "default-runtime-attributes.efsDelocalize",
     "default-runtime-attributes.efsMakeMD5",

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAttributes.scala
@@ -87,6 +87,7 @@ object AwsBatchAttributes {
     "numSubmitAttempts",
     "default-runtime-attributes.scriptBucketName",
     "awsBatchRetryAttempts",
+    "awsBatchEvaluateOnExit",
     "ulimits",
     "efsDelocalize",
     "efsMakeMD5",

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
@@ -44,10 +44,14 @@ import wom.RuntimeAttributesKeys
 import wom.format.MemorySize
 import wom.types._
 import wom.values._
-import com.typesafe.config.{ConfigException,ConfigValueFactory}
+import com.typesafe.config.{ConfigException, ConfigValueFactory}
 
 import scala.util.matching.Regex
 import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.{Failure, Success, Try}
+import scala.jdk.CollectionConverters._
+
 
 /**
  * Attributes that are provided to the job at runtime
@@ -63,6 +67,7 @@ import org.slf4j.{Logger, LoggerFactory}
  * @param scriptS3BucketName the s3 bucket where the execution command or script will be written and, from there, fetched into the container and executed
  * @param fileSystem the filesystem type, default is "s3"
  * @param awsBatchRetryAttempts number of attempts that AWS Batch will retry the task if it fails
+ * @param awsBatchEvaluateOnExit Evaluate on exit strategy setting for AWS batch retry
  * @param ulimits ulimit values to be passed to the container
  * @param efsDelocalize should we delocalize efs files to s3
  * @param efsMakeMD5 should we make a sibling md5 file as part of the job 
@@ -78,6 +83,7 @@ case class AwsBatchRuntimeAttributes(cpu: Int Refined Positive,
                                      noAddress: Boolean,
                                      scriptS3BucketName: String,
                                      awsBatchRetryAttempts: Int,
+                                     awsBatchEvaluateOnExit: Vector[Map[String, String]],
                                      ulimits: Vector[Map[String, String]],
                                      efsDelocalize: Boolean,
                                      efsMakeMD5 : Boolean,
@@ -90,6 +96,10 @@ object AwsBatchRuntimeAttributes {
   val scriptS3BucketKey = "scriptBucketName"
 
   val awsBatchRetryAttemptsKey = "awsBatchRetryAttempts"
+
+  val awsBatchEvaluateOnExitKey = "awsBatchEvaluateOnExit"
+  private val awsBatchEvaluateOnExitDefault = WomArray(WomArrayType(WomMapType(WomStringType,WomStringType)), Vector(WomMap(Map.empty[WomValue, WomValue])))
+
 
   val awsBatchefsDelocalizeKey = "efsDelocalize"
   val awsBatchefsMakeMD5Key = "efsMakeMD5"
@@ -157,6 +167,11 @@ object AwsBatchRuntimeAttributes {
     .configDefaultWomValue(runtimeConfig).getOrElse(WomInteger(0)))
   }
 
+  def awsBatchEvaluateOnExitValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Vector[Map[String, String]]] = {
+    AwsBatchEvaluateOnExitValidation
+      .withDefault(AwsBatchEvaluateOnExitValidation.fromConfig(runtimeConfig).getOrElse(awsBatchEvaluateOnExitDefault))
+  }
+
   private def awsBatchefsDelocalizeValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Boolean] = {
     AwsBatchefsDelocalizeValidation(awsBatchefsDelocalizeKey).withDefault(AwsBatchefsDelocalizeValidation(awsBatchefsDelocalizeKey)
     .configDefaultWomValue(runtimeConfig).getOrElse(WomBoolean(false)))
@@ -199,7 +214,6 @@ object AwsBatchRuntimeAttributes {
 
   def runtimeAttributesBuilder(configuration: AwsBatchConfiguration): StandardValidatedRuntimeAttributesBuilder = {
     val runtimeConfig = aggregateDisksInRuntimeConfig(configuration)
-    
     def validationsS3backend = StandardValidatedRuntimeAttributesBuilder.default(runtimeConfig).withValidation(
                         cpuValidation(runtimeConfig),
                         cpuMinValidation(runtimeConfig),
@@ -212,6 +226,7 @@ object AwsBatchRuntimeAttributes {
                         queueArnValidation(runtimeConfig),
                         scriptS3BucketNameValidation(runtimeConfig),
                         awsBatchRetryAttemptsValidation(runtimeConfig),
+                        awsBatchEvaluateOnExitValidation(runtimeConfig),
                         ulimitsValidation(runtimeConfig),
                         awsBatchefsDelocalizeValidation(runtimeConfig),
                         awsBatchefsMakeMD5Validation(runtimeConfig)
@@ -227,6 +242,7 @@ object AwsBatchRuntimeAttributes {
       dockerValidation,
       queueArnValidation(runtimeConfig),
       awsBatchRetryAttemptsValidation(runtimeConfig),
+      awsBatchEvaluateOnExitValidation(runtimeConfig),
       ulimitsValidation(runtimeConfig),
       awsBatchefsDelocalizeValidation(runtimeConfig),
       awsBatchefsMakeMD5Validation(runtimeConfig)
@@ -254,6 +270,8 @@ object AwsBatchRuntimeAttributes {
        case _ => ""
     }
     val awsBatchRetryAttempts: Int = RuntimeAttributesValidation.extract(awsBatchRetryAttemptsValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
+    val awsBatchEvaluateOnExit: Vector[Map[String, String]] = RuntimeAttributesValidation.extract(awsBatchEvaluateOnExitValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
+
     val ulimits: Vector[Map[String, String]] = RuntimeAttributesValidation.extract(ulimitsValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
     val efsDelocalize: Boolean = RuntimeAttributesValidation.extract(awsBatchefsDelocalizeValidation(runtimeAttrsConfig),validatedRuntimeAttributes)
     val efsMakeMD5: Boolean = RuntimeAttributesValidation.extract(awsBatchefsMakeMD5Validation(runtimeAttrsConfig),validatedRuntimeAttributes)
@@ -270,6 +288,7 @@ object AwsBatchRuntimeAttributes {
       noAddress,
       scriptS3BucketName,
       awsBatchRetryAttempts,
+      awsBatchEvaluateOnExit,
       ulimits,
       efsDelocalize,
       efsMakeMD5,
@@ -473,6 +492,115 @@ class AwsBatchRetryAttemptsValidation(key: String) extends IntRuntimeAttributesV
   override protected def missingValueMessage: String = s"Expecting $key runtime attribute to be an Integer"
 }
 
+object AwsBatchEvaluateOnExitValidation extends RuntimeAttributesValidation[Vector[Map[String, String]]] {
+
+  val requiredKey = "action"
+  private val acceptedKeys = Set(requiredKey, "onExitCode", "onReason", "onStatusReason")
+
+
+  def fromConfig(runtimeConfig: Option[Config]): Option[WomValue]= {
+    val config = runtimeConfig match {
+      case Some(value) => Try(value.getObjectList(key)) match {
+        case Failure(_) => None
+        case Success(value) => Some(value.asScala.map {
+          _.unwrapped().asScala.toMap
+        }.toList)
+      }
+      case _ => None
+    }
+
+    config match {
+      case Some(value) => Some(AwsBatchEvaluateOnExitValidation
+        .coercion collectFirst {
+        case womType if womType.coerceRawValue(value).isSuccess => womType.coerceRawValue(value).get
+      } getOrElse {
+        BadDefaultAttribute(WomString(value.toString))
+      })
+      case None => None
+    }
+  }
+
+  override def coercion: Iterable[WomType] = {
+    Set(WomStringType, WomArrayType(WomMapType(WomStringType, WomStringType)))
+  }
+
+  override protected def validateValue: PartialFunction[WomValue, ErrorOr[Vector[Map[String, String]]]] = {
+    case WomArray(womType, value)
+      if womType.memberType == WomMapType(WomStringType, WomStringType) =>
+      check_maps(value.toVector)
+    case WomMap(_, _) => "!!! ERROR1".invalidNel
+  }
+
+  private def check_maps(
+                          maps: Vector[WomValue]
+                        ): ErrorOr[Vector[Map[String, String]]] = {
+    val entryNels: Vector[ErrorOr[Map[String, String]]] = maps.map {
+      case WomMap(_, value) => check_keys(value)
+      case _ => "!!! ERROR2".invalidNel
+    }
+    val sequenced: ErrorOr[Vector[Map[String, String]]] = sequenceNels(
+      entryNels
+    )
+    sequenced
+  }
+
+  private def validateActionKey(dict: Map[WomValue, WomValue]): ErrorOr[Map[String, String]] = {
+    val validCondition = Set("retry", "exit")
+    val convertedMap = dict
+      .map { case (WomString(k), WomString(v)) =>
+        (k, v)
+        // case _ => "!!! ERROR3".invalidNel
+      }
+    if (convertedMap.exists {
+      case (key, value) => key.toLowerCase == requiredKey && validCondition.contains(value.toLowerCase)
+    }) {
+      convertedMap.validNel
+    }
+    else {
+      s"Missing or invalid $requiredKey key/value for runtime attribute: $key. Refer to https://docs.aws.amazon.com/batch/latest/APIReference/API_RetryStrategy.html".invalidNel
+    }
+  }
+
+  private def check_keys(
+                          dict: Map[WomValue, WomValue]
+                        ): ErrorOr[Map[String, String]] = {
+    val map_keys = dict.keySet.map(_.valueString.toLowerCase)
+    val unrecognizedKeys =
+      map_keys.diff(acceptedKeys.map(x => x.toLowerCase))
+    if (!dict.nonEmpty) {
+      Map.empty[String, String].validNel
+    }
+    else if (unrecognizedKeys.nonEmpty) {
+      s"Invalid keys in $key runtime attribute: $unrecognizedKeys. Only $acceptedKeys are accepted. Refer to https://docs.aws.amazon.com/batch/latest/APIReference/API_RetryStrategy.html".invalidNel
+    }
+    else {
+      validateActionKey(dict)
+    }
+  }
+
+  private def sequenceNels(
+                            nels: Vector[ErrorOr[Map[String, String]]]
+                          ): ErrorOr[Vector[Map[String, String]]] = {
+    val emptyNel: ErrorOr[Vector[Map[String, String]]] =
+      Vector.empty[Map[String, String]].validNel
+    val seqNel: ErrorOr[Vector[Map[String, String]]] =
+      nels.foldLeft(emptyNel) { (acc, v) =>
+        (acc, v) mapN { (a, v) => a :+ v }
+      }
+    seqNel
+  }
+
+
+  override protected def missingValueMessage: String = s"Expecting $key runtime attribute to be defined"
+
+  /**
+   * Returns the key of the runtime attribute.
+   *
+   * @return The key of the runtime attribute.
+   */
+  override def key: String = AwsBatchRuntimeAttributes.awsBatchEvaluateOnExitKey
+}
+
 object AwsBatchefsDelocalizeValidation {
   def apply(key: String): AwsBatchefsDelocalizeValidation = new AwsBatchefsDelocalizeValidation(key)
 }
@@ -531,7 +659,7 @@ object UlimitsValidation
       accepted_keys.diff(map_keys) union map_keys.diff(accepted_keys)
 
     if (!dict.nonEmpty){
-      Map.empty[String, String].validNel  
+      Map.empty[String, String].validNel
     }else if (unrecognizedKeys.nonEmpty) {
       s"Invalid keys in $key runtime attribute. Refer to 'ulimits' section on https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#containerProperties".invalidNel
     } else {

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md
@@ -75,6 +75,37 @@ runtime {
 }
 ```
 
+### `awsBatchEvaluteOnExit`
+
+*Default: _[]_* - will always retry 
+
+This runtime attribute sets the `evaluateOnExit` for [*AWS Batch Automated Job Retries*](https://docs.aws.amazon.com/batch/latest/userguide/job_retries.html) and specify the retry condition for a failed job.
+
+This configuration works with `awsBatchRetryAttempts` and is useful if you only want to retry on certain failures. 
+
+For instance, if you will only like to retry during spot termination.
+
+```
+runtime {
+    awsBatchEvaluateOnExit: [
+        {  
+            Action: "RETRY",
+            onStatusReason: "Host EC2*"
+        },
+        {
+            onReason : "*"
+            Action: "EXIT"
+        }
+    ]
+}
+```
+
+For more information on the batch retry strategy, please refer to:
+
+* General Doc: [userguide/job_retries.html](https://docs.aws.amazon.com/batch/latest/userguide/job_retries.html)
+* Blog: [Introducing retry strategies](https://aws.amazon.com/blogs/compute/introducing-retry-strategies-for-aws-batch/)
+
+
 ### `ulimits`
 
 *Default: _empty_*

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -32,7 +32,7 @@
 package cromwell.backend.impl.aws
 
 import common.collections.EnhancedCollections._
-import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
+import cromwell.backend.{BackendJobDescriptor, BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.backend.BackendSpec._
 import cromwell.backend.impl.aws.io.{AwsBatchJobPaths, AwsBatchWorkflowPaths, AwsBatchWorkingDisk}
 import cromwell.backend.validation.ContinueOnReturnCodeFlag
@@ -46,7 +46,7 @@ import org.scalatest.PrivateMethodTester
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.services.batch.model.{ContainerDetail, JobDetail, KeyValuePair}
+import software.amazon.awssdk.services.batch.model.{ContainerDetail, EvaluateOnExit, JobDetail, KeyValuePair, RetryAction, RetryStrategy}
 import spray.json.{JsObject, JsString}
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
@@ -100,6 +100,8 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
 
   val call: CommandCallNode = workFlowDescriptor.callable.taskCallNodes.head
   val jobKey: BackendJobDescriptorKey = BackendJobDescriptorKey(call, None, 1)
+  val jobDescriptor: BackendJobDescriptor = BackendJobDescriptor(null, null, null, Map.empty, null, null, null)
+
   val jobPaths: AwsBatchJobPaths = AwsBatchJobPaths(workflowPaths, jobKey)
   val s3Inputs: Set[AwsBatchInput] = Set(AwsBatchFileInput("foo", "s3://bucket/foo", DefaultPathBuilder.get("foo"), AwsBatchWorkingDisk()))
   val s3Outputs: Set[AwsBatchFileOutput] = Set(AwsBatchFileOutput("baa", "s3://bucket/somewhere/baa", DefaultPathBuilder.get("baa"), AwsBatchWorkingDisk()))
@@ -117,10 +119,18 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       noAddress = false,
       scriptS3BucketName = "script-bucket",
       awsBatchRetryAttempts = 1,
+      awsBatchEvaluateOnExit = Vector(Map.empty[String, String]),
       ulimits = Vector(Map.empty[String, String]),
       efsDelocalize = false,
       efsMakeMD5 = false,
       fileSystem = "s3")
+
+  val batchJobDefintion = AwsBatchJobDefinitionContext(
+    runtimeAttributes = runtimeAttributes,
+    commandText = "", dockerRcPath = "", dockerStdoutPath = "", dockerStderrPath = "", jobDescriptor = jobDescriptor
+    , jobPaths = jobPaths, inputs = Set(), outputs = Set(), fsxMntPoint = None, None, None, None
+
+  )
 
   val containerDetail: ContainerDetail = ContainerDetail.builder().exitCode(0).build()
   val jobDetail: JobDetail = JobDetail.builder().container(containerDetail).build
@@ -351,8 +361,6 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
     job.reconfiguredScript should include (postscript)
   }
 
-
-
   it should "generate preamble with input copy command in reconfigured script" in {
     val job = generateJobWithS3InOut
     val preamble =
@@ -388,5 +396,37 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
     val jobDetail: JobDetail = JobDetail.builder().container(containerDetail).build
     val job = generateBasicJob
     job.rc(jobDetail) should be (0)
+  }
+
+  it should "use RetryStrategy" in {
+    val runtime = runtimeAttributes.copy(
+      awsBatchEvaluateOnExit = Vector(Map("action" -> "EXIT", "onStatusReason" -> "Failed")),
+    )
+
+    val builder = RetryStrategy.builder().attempts(1).evaluateOnExit(
+      EvaluateOnExit.builder().onStatusReason("Failed").action(RetryAction.EXIT).build()
+    ).build()
+
+    val jobDefinition = StandardAwsBatchJobDefinitionBuilder.build(batchJobDefintion.copy(runtimeAttributes = runtime))
+    val jobDefinitionName = jobDefinition.name
+    val expected = jobDefinition.retryStrategy
+    expected should equal (builder)
+    jobDefinitionName should equal ("cromwell_ubuntu_latest_656d5a7e7cd016d2360b27bc5ee75018d91a777a")
+  }
+
+  it should "use RetryStrategy evaluateOnExit should be case insensitive" in {
+    val runtime = runtimeAttributes.copy(
+      awsBatchEvaluateOnExit = Vector(Map("aCtIoN" -> "EXIT", "onStatusReason" -> "Failed")),
+    )
+
+    val builder = RetryStrategy.builder().attempts(1).evaluateOnExit(
+      EvaluateOnExit.builder().onStatusReason("Failed").action(RetryAction.EXIT).build()
+    ).build()
+
+    val jobDefinition = StandardAwsBatchJobDefinitionBuilder.build(batchJobDefintion.copy(runtimeAttributes = runtime))
+    val jobDefinitionName = jobDefinition.name
+    val expected = jobDefinition.retryStrategy
+    expected should equal(builder)
+    jobDefinitionName should equal("cromwell_ubuntu_latest_66a335d761780e64e6b154339c5f1db2f0783f96")
   }
 }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
@@ -48,6 +48,8 @@ import wom.format.MemorySize
 import wom.types._
 import wom.values._
 
+import scala.util.{Failure, Success, Try}
+
 class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec with Matchers {
 
   def workflowOptionsWithDefaultRA(defaults: Map[String, JsValue]): WorkflowOptions = {
@@ -67,6 +69,7 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     "my-stuff",
     1,
     Vector(Map.empty[String, String]),
+    Vector(Map.empty[String, String]),
     false,
     false
   )
@@ -81,6 +84,7 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     false,
     "",
     1,
+    Vector(Map.empty[String, String]),
     Vector(Map.empty[String, String]),
     false,
     false,
@@ -191,9 +195,9 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
       assertAwsBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
     }
     "validate a valid Filesystem string entry local Filesystem" in {
-      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"),"scriptBucketName" -> WomString(""), "filesystem" -> WomString("local"))
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "scriptBucketName" -> WomString(""), "filesystem" -> WomString("local"))
       val expectedRuntimeAttributes = expectedDefaultsLocalFS
-      assertAwsBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes,WorkflowOptions.fromMap(Map.empty).get,
+      assertAwsBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes, WorkflowOptions.fromMap(Map.empty).get,
         NonEmptyList.of("us-east-1a", "us-east-1b"), new AwsBatchConfiguration(AwsBatchTestConfigForLocalFS.AwsBatchBackendConfigurationDescriptor))
     }
 
@@ -307,7 +311,7 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     }
 
     "override config default attributes with default attributes declared in workflow options" in {
-      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "scriptBucketName" -> WomString("my-stuff") )
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "scriptBucketName" -> WomString("my-stuff"))
 
       val workflowOptionsJson =
         """{
@@ -321,7 +325,7 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     }
 
     "override config default runtime attributes with task runtime attributes" in {
-      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "scriptBucketName" -> WomString("my-stuff"),  "cpu" -> WomInteger(4))
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "scriptBucketName" -> WomString("my-stuff"), "cpu" -> WomInteger(4))
 
       val workflowOptionsJson =
         """{
@@ -335,7 +339,7 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     }
 
     "override invalid config default attributes with task runtime attributes" in {
-      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"),"scriptBucketName" -> WomString("my-stuff"),  "cpu" -> WomInteger(4))
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "scriptBucketName" -> WomString("my-stuff"), "cpu" -> WomInteger(4))
 
       val workflowOptionsJson =
         """{
@@ -374,6 +378,89 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
       val expectedRuntimeAttributes = expectedDefaults.copy(awsBatchRetryAttempts = 0)
       assertAwsBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
     }
+
+    "validate a valid awsBatchEvaluateOnExit " in {
+      val runtimeAttributes = Map(
+        "docker" -> WomString("ubuntu:latest"),
+        "awsBatchRetryAttempts" -> WomInteger(0),
+        "scriptBucketName" -> WomString("my-stuff"),
+        "awsBatchEvaluateOnExit" -> WomArray(
+          Seq(WomMap(Map(WomString("action") -> WomString("RETRY"), WomString("onStatusReason") -> WomString("Host EC2*")))
+          )
+        )
+      )
+
+      assertAwsBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedDefaults.copy(
+        awsBatchRetryAttempts = 0,
+        awsBatchEvaluateOnExit = Vector(Map("action" -> "RETRY", "onStatusReason" -> "Host EC2*"))
+      ))
+    }
+
+    "if awsBatchEvaluteOnExit is empty, do not fail" in {
+      val runtimeAttributes = Map(
+        "docker" -> WomString("ubuntu:latest"),
+        "awsBatchRetryAttempts" -> WomInteger(0),
+        "scriptBucketName" -> WomString("my-stuff"),
+        "awsBatchEvaluateOnExit" -> WomArray(WomArrayType(WomMapType(WomStringType,WomStringType)), Vector(WomMap(Map.empty[WomValue, WomValue])))
+      )
+      assertAwsBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedDefaults.copy(
+        awsBatchRetryAttempts = 0,
+      ))
+    }
+
+    "missing or invalid action key result in an invalid awsBatchEvaluateOnExit" in {
+      val invalidEvaluateOnExit = List(
+        // missing action key
+        WomArray(
+          Seq(WomMap(Map(WomString("onStatusReason") -> WomString("Host EC2*")))
+          )
+        ),
+        // invalid value
+        WomArray(
+          Seq(WomMap(Map(WomString("action") -> WomString("TRYAGAIN"), WomString("onStatusReason") -> WomString("Host EC2*")))
+          )
+        )
+      )
+
+      invalidEvaluateOnExit foreach { invalidVal =>
+        val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "awsBatchEvaluateOnExit" -> invalidVal)
+        assertAwsBatchRuntimeAttributesFailedCreation(runtimeAttributes,
+          "Missing or invalid action key/value for runtime attribute: awsBatchEvaluateOnExit")
+      }
+    }
+  }
+
+  "Unrecognized keys for retry strategy should result in an invalid awsBatchEvaluateOnExit" in {
+    // invalid key
+    val invalidValue = WomArray(
+      Seq(WomMap(Map(WomString("action") -> WomString("RETRY"), WomString("onRandomStatus") -> WomString("Host EC2*")))
+      )
+    )
+    val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "awsBatchEvaluateOnExit" -> invalidValue)
+    assertAwsBatchRuntimeAttributesFailedCreation(runtimeAttributes,
+      s"""Invalid keys in awsBatchEvaluateOnExit runtime attribute: Set(onrandomstatus).
+         | Only Set(action, onExitCode, onReason, onStatusReason) are accepted.""".stripMargin.replace(
+        "\n", ""))
+  }
+
+  "Config with defined awsBatchEvaluateOnExit works" in {
+    val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "scriptBucketName" -> WomString("my-stuff"),
+    )
+    val batchConfig = new AwsBatchConfiguration(AwsBatchTestWithRetryConfig.AwsBatchBackendConfigurationDescriptor)
+    val workflowOptions = WorkflowOptions.fromMap(Map.empty).get
+    val expectedRuntimeAttributes = expectedDefaults.copy(
+      awsBatchEvaluateOnExit = Vector(
+        Map("Action" -> "RETRY", "onStatusReason" -> "Host EC2*"), Map("Action" -> "EXIT", "onReason" -> "*"))
+    )
+
+    val runtimeAttributesBuilder = AwsBatchRuntimeAttributes.runtimeAttributesBuilder(batchConfig)
+    val defaultedAttributes = RuntimeAttributeDefinition.addDefaultsToAttributes(
+      AwsBatchRuntimeAttributes.runtimeAttributesBuilder(batchConfig).definitions.toSet, workflowOptions)(runtimeAttributes)
+
+    val validatedRuntimeAttributes = runtimeAttributesBuilder.build(defaultedAttributes, NOPLogger.NOP_LOGGER)
+    val actualRuntimeAttributes = AwsBatchRuntimeAttributes(
+      validatedRuntimeAttributes, batchConfig.runtimeConfig, batchConfig.fileSystem)
+    assert(actualRuntimeAttributes == expectedRuntimeAttributes)
   }
 
   private def assertAwsBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WomValue],
@@ -393,11 +480,10 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
   private def assertAwsBatchRuntimeAttributesFailedCreation(runtimeAttributes: Map[String, WomValue],
                                                        exMsg: String,
                                                        workflowOptions: WorkflowOptions = emptyWorkflowOptions): Unit = {
-    try {
-      toAwsBatchRuntimeAttributes(runtimeAttributes, workflowOptions, configuration)
-      fail(s"A RuntimeException was expected with message: $exMsg")
-    } catch {
-      case ex: RuntimeException => assert(ex.getMessage.contains(exMsg))
+
+    Try(toAwsBatchRuntimeAttributes(runtimeAttributes, workflowOptions, configuration)) match {
+      case Failure(exception) => assert(exception.getMessage.contains(exMsg))
+      case Success(_) => fail(s"A RuntimeException was expected with message: $exMsg")
     }
     ()
   }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
@@ -193,3 +193,93 @@ object AwsBatchTestConfigForLocalFS {
   val AwsBatchBackendConfigurationDescriptor = BackendConfigurationDescriptor(AwsBatchBackendConfig, AwsBatchGlobalConfig)
   val NoDefaultsConfigurationDescriptor = BackendConfigurationDescriptor(AwsBatchBackendNoDefaultConfig, AwsBatchGlobalConfig)
 }
+
+object AwsBatchTestWithRetryConfig {
+
+  private val AwsBatchBackendConfigString =
+    """
+      |root = "s3://my-cromwell-workflows-bucket"
+      |
+      |filesystems {
+      |  s3 {
+      |    auth = "default"
+      |  }
+      |}
+      |
+      |auth = "default"
+      |   numSubmitAttempts = 6
+      |   numCreateDefinitionAttempts = 6
+      |
+      |default-runtime-attributes {
+      |    cpu: 1
+      |    failOnStderr: false
+      |    continueOnReturnCode: 0
+      |    docker: "ubuntu:latest"
+      |    memory: "2 GB"
+      |    disks: "local-disk"
+      |    noAddress: false
+      |    zones:["us-east-1a", "us-east-1b"]
+      |    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
+      |    scriptBucketName: "my-bucket"
+      |    awsBatchRetryAttempts: 1
+      |    awsBatchEvaluateOnExit: [
+      |     {
+      |       Action: "RETRY",
+      |       onStatusReason: "Host EC2*"
+      |     },
+      |     {
+      |  		  onReason : "*"
+      |       Action: "EXIT"
+      |     }
+      |    ]
+      |}
+      |
+      |""".stripMargin
+
+  private val NoDefaultsConfigString =
+    """
+      |root = "s3://my-cromwell-workflows-bucket"
+      |
+      |auth = "default"
+      |   numSubmitAttempts = 6
+      |   numCreateDefinitionAttempts = 6
+      |
+      |filesystems {
+      |  s3 {
+      |    auth = "default"
+      |  }
+      |}
+      |""".stripMargin
+
+  private val AwsBatchGlobalConfigString =
+    s"""
+       |aws {
+       |  application-name = "cromwell"
+       |  auths = [
+       |    {
+       |      name = "default"
+       |      scheme = "default"
+       |    }
+       |  ]
+       |}
+       |
+       |backend {
+       |  default = "AWS"
+       |  providers {
+       |    AWS {
+       |      actor-factory = "cromwell.backend.impl.aws.AwsBatchBackendLifecycleFactory"
+       |      config {
+       |      $AwsBatchBackendConfigString
+       |      }
+       |    }
+       |  }
+       |}
+       |
+       |""".stripMargin
+
+  val AwsBatchBackendConfig = ConfigFactory.parseString(AwsBatchBackendConfigString)
+  val AwsBatchGlobalConfig = ConfigFactory.parseString(AwsBatchGlobalConfigString)
+  val AwsBatchBackendNoDefaultConfig = ConfigFactory.parseString(NoDefaultsConfigString)
+  val AwsBatchBackendConfigurationDescriptor = BackendConfigurationDescriptor(AwsBatchBackendConfig, AwsBatchGlobalConfig)
+  val NoDefaultsConfigurationDescriptor = BackendConfigurationDescriptor(AwsBatchBackendNoDefaultConfig, AwsBatchGlobalConfig)
+}


### PR DESCRIPTION
Hi @henriqueribeiro,

This is a PR for the `awsBatchEvaluateOnExit` feature.

## Changes made

Using the same pattern for `awsBatchRetryAttempts`, I made the following changes:
- Added `awsBatchEvaluateOnExit` as part of `AwsBatchRuntimeAttributes`
- Addded `AwsBatchEvaluateOnExitValidation` and use if for creating jobs.
- Updated `retryStrategyBuilder` to include evaluateOnExit value
- Fixed `assertAwsBatchRuntimeAttributesFailedCreation` as it will always pass because `fail` is a throws a runtimeException.
- Added various tests and has tested it on various manual run. Will continue testing it.

## Discussion

I have kept `awsBatchEvaluateOnExit` as a separate run time attribute instead of combining it with `awsBatchRetryAttempts` as coercion of nested values between womtype and scala type can be tricky.

We are continuously testing it internally but will to to put up this PR to hear what you think -  we were able to get it working by setting it as default-runtime-attribute as will as task level attribute.

I also noticed that i wasnt able to coerce the List of Map directly from Config to WomArray(WomMap(WomString, WomString)) so im have to add a additional method `fromConfig` for `AwsBatchEvaluateOnExitValidation`. 
