### PR TITLE
Multi-asterisk globbing

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -47,15 +47,22 @@ import common.util.StringUtil._
 import common.validation.Validation._
 
 import cromwell.backend._
-import cromwell.backend.async._ 
+import cromwell.backend.async._
 import cromwell.backend.impl.aws.IntervalLimitedAwsJobSubmitActor.SubmitAwsJobRequest
-import cromwell.backend.impl.aws.OccasionalStatusPollingActor.{NotifyOfStatus, WhatsMyStatus}
+import cromwell.backend.impl.aws.OccasionalStatusPollingActor.{
+  NotifyOfStatus,
+  WhatsMyStatus
+}
 import cromwell.backend.impl.aws.RunStatus.{Initializing, TerminalRunStatus}
 import cromwell.backend.impl.aws.io._
 
 import cromwell.backend.io.DirectoryFunctions
 import cromwell.backend.io.JobPaths
-import cromwell.backend.standard.{StandardAsyncExecutionActor, StandardAsyncExecutionActorParams, StandardAsyncJob}
+import cromwell.backend.standard.{
+  StandardAsyncExecutionActor,
+  StandardAsyncExecutionActorParams,
+  StandardAsyncJob
+}
 import cromwell.backend.OutputEvaluator._
 import cromwell.core._
 import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder, PathFactory}
@@ -83,56 +90,77 @@ import scala.language.postfixOps
 import scala.util.control.NoStackTrace
 import scala.util.{Success, Try, Failure}
 
-/**
-  * The `AwsBatchAsyncBackendJobExecutionActor` creates and manages a job. The job itself is encapsulated by the
-  * functionality in `AwsBatchJob`
+/** The `AwsBatchAsyncBackendJobExecutionActor` creates and manages a job. The
+  * job itself is encapsulated by the functionality in `AwsBatchJob`
   */
 object AwsBatchAsyncBackendJobExecutionActor {
   val AwsBatchOperationIdKey = "__aws_batch_operation_id"
 
-  type AwsBatchPendingExecutionHandle = PendingExecutionHandle[StandardAsyncJob, AwsBatchJob, RunStatus]
+  type AwsBatchPendingExecutionHandle =
+    PendingExecutionHandle[StandardAsyncJob, AwsBatchJob, RunStatus]
 }
 
-class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: StandardAsyncExecutionActorParams)
-  extends BackendJobLifecycleActor with StandardAsyncExecutionActor with AwsBatchJobCachingActorHelper
-    with KvClient with AskSupport {
+class AwsBatchAsyncBackendJobExecutionActor(
+    override val standardParams: StandardAsyncExecutionActorParams
+) extends BackendJobLifecycleActor
+    with StandardAsyncExecutionActor
+    with AwsBatchJobCachingActorHelper
+    with KvClient
+    with AskSupport {
 
-  /**
-    * The builder for `IoCommands` to the storage system used by jobs executed by this backend
+  /** The builder for `IoCommands` to the storage system used by jobs executed
+    * by this backend
     */
-  override lazy val ioCommandBuilder: IoCommandBuilder = configuration.fileSystem match  {
-    case AWSBatchStorageSystems.s3 => S3BatchCommandBuilder
-    case _ =>  DefaultIoCommandBuilder
-  }
+  override lazy val ioCommandBuilder: IoCommandBuilder =
+    configuration.fileSystem match {
+      case AWSBatchStorageSystems.s3 => S3BatchCommandBuilder
+      case _                         => DefaultIoCommandBuilder
+    }
 
   // the cromwell backend Actor
   val backendSingletonActor: ActorRef =
     standardParams.backendSingletonActorOption.getOrElse(
-      throw new RuntimeException(s"AWS Backend actor cannot exist without its backend singleton (of type ${AwsBatchSingletonActor.getClass.getSimpleName})"))
+      throw new RuntimeException(
+        s"AWS Backend actor cannot exist without its backend singleton (of type ${AwsBatchSingletonActor.getClass.getSimpleName})"
+      )
+    )
 
   import AwsBatchAsyncBackendJobExecutionActor._
 
-  val Log: Logger = LoggerFactory.getLogger(AwsBatchAsyncBackendJobExecutionActor.getClass)
+  val Log: Logger =
+    LoggerFactory.getLogger(AwsBatchAsyncBackendJobExecutionActor.getClass)
 
   override type StandardAsyncRunInfo = AwsBatchJob
 
   override type StandardAsyncRunState = RunStatus
 
-  /**
-    * Determines if two run statuses are equal
-    * @param thiz a `RunStatus`
-    * @param that a `RunStatus`
-    * @return true if they are equal, else false
+  /** Determines if two run statuses are equal
+    * @param thiz
+    *   a `RunStatus`
+    * @param that
+    *   a `RunStatus`
+    * @return
+    *   true if they are equal, else false
     */
-  def statusEquivalentTo(thiz: StandardAsyncRunState)(that: StandardAsyncRunState): Boolean = thiz == that
+  def statusEquivalentTo(thiz: StandardAsyncRunState)(
+      that: StandardAsyncRunState
+  ): Boolean = thiz == that
 
-  override lazy val pollBackOff: SimpleExponentialBackoff = SimpleExponentialBackoff(1.second, 5.minutes, 1.1)
+  override lazy val pollBackOff: SimpleExponentialBackoff =
+    SimpleExponentialBackoff(1.second, 5.minutes, 1.1)
 
-  override lazy val executeOrRecoverBackOff: SimpleExponentialBackoff = SimpleExponentialBackoff(
-    initialInterval = 3 seconds, maxInterval = 20 seconds, multiplier = 1.1)
+  override lazy val executeOrRecoverBackOff: SimpleExponentialBackoff =
+    SimpleExponentialBackoff(
+      initialInterval = 3 seconds,
+      maxInterval = 20 seconds,
+      multiplier = 1.1
+    )
 
-  //the name (String) of the docker image that will be used to contain this job
-  private lazy val jobDockerImage = jobDescriptor.maybeCallCachingEligible.dockerHash.getOrElse(runtimeAttributes.dockerImage)
+  // the name (String) of the docker image that will be used to contain this job
+  private lazy val jobDockerImage =
+    jobDescriptor.maybeCallCachingEligible.dockerHash.getOrElse(
+      runtimeAttributes.dockerImage
+    )
 
   override lazy val dockerImageUsed: Option[String] = Option(jobDockerImage)
 
@@ -143,7 +171,6 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         |find ${jobPaths.script.parent.pathWithoutScheme} -group root | grep -v script | xargs rm -vrf
         |${jobPaths.script.pathWithoutScheme}
         |""".stripMargin
-
 
   /* Batch job object (see AwsBatchJob). This has the configuration necessary
    * to perform all operations with the AWS Batch infrastructure. This is
@@ -178,13 +205,14 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
    * commandScriptContents here
    */
 
-   /* part of the full commandScriptContents is overriden here, in the context of mixed S3/EFS support with globbing. 
+  /* part of the full commandScriptContents is overriden here, in the context of mixed S3/EFS support with globbing.
       we'll see how much we need...
-    */ 
+   */
 
   lazy val cmdScript = configuration.fileSystem match {
-     case AWSBatchStorageSystems.s3 => commandScriptContents.toEither.toOption.get
-     case _ => execScript
+    case AWSBatchStorageSystems.s3 =>
+      commandScriptContents.toEither.toOption.get
+    case _ => execScript
   }
 
   lazy val batchJob: AwsBatchJob = {
@@ -193,17 +221,21 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       runtimeAttributes,
       instantiatedCommand.commandString,
       cmdScript,
-      rcPath.toString, executionStdout, executionStderr,
+      rcPath.toString,
+      executionStdout,
+      executionStderr,
       generateAwsBatchInputs(jobDescriptor),
       generateAwsBatchOutputs(jobDescriptor),
-      jobPaths, Seq.empty[AwsBatchParameter],
+      jobPaths,
+      Seq.empty[AwsBatchParameter],
       configuration.awsConfig.region,
       Option(configuration.awsAuth),
       configuration.fsxMntPoint,
       configuration.efsMntPoint,
       Option(runtimeAttributes.efsMakeMD5),
       Option(runtimeAttributes.efsDelocalize),
-      Option(runtimeAttributes.tagResources))
+      Option(runtimeAttributes.tagResources)
+    )
   }
 
   // setup batch client to query job container info
@@ -219,91 +251,125 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
    *
    */
   override def tryAbort(job: StandardAsyncJob): Unit = {
-    batchJob.abort(job.jobId) // job.JobId should be the AWS Batch Job Id based on analysis of other backends
-    Log.info(s"Attempted CancelJob operation in AWS Batch for Job ID ${job.jobId}. There were no errors during the operation")
-    Log.info(s"We have normality. Anything you still can't cope with is therefore your own problem")
+    batchJob.abort(
+      job.jobId
+    ) // job.JobId should be the AWS Batch Job Id based on analysis of other backends
+    Log.info(
+      s"Attempted CancelJob operation in AWS Batch for Job ID ${job.jobId}. There were no errors during the operation"
+    )
+    Log.info(
+      s"We have normality. Anything you still can't cope with is therefore your own problem"
+    )
     Log.info(s"https://www.youtube.com/watch?v=YCRxnjE7JVs")
     ()
   }
 
   override def requestsAbortAndDiesImmediately: Boolean = false
 
-  /**
-    * Takes two arrays of remote and local WOM File paths and generates the necessary AwsBatchInputs.
+  /** Takes two arrays of remote and local WOM File paths and generates the
+    * necessary AwsBatchInputs.
     */
-  private def inputsFromWomFiles(namePrefix: String,
-                                    remotePathArray: Seq[WomFile],
-                                    localPathArray: Seq[WomFile],
-                                    jobDescriptor: BackendJobDescriptor,
-                                    flag: Boolean): Iterable[AwsBatchInput] = {
+  private def inputsFromWomFiles(
+      namePrefix: String,
+      remotePathArray: Seq[WomFile],
+      localPathArray: Seq[WomFile],
+      jobDescriptor: BackendJobDescriptor,
+      flag: Boolean
+  ): Iterable[AwsBatchInput] = {
 
     (remotePathArray zip localPathArray zipWithIndex) flatMap {
       case ((remotePath, localPath), index) =>
         var localPathString = localPath.valueString
-        if (localPathString.startsWith("s3://")){
+        if (localPathString.startsWith("s3://")) {
           localPathString = localPathString.replace("s3://", "")
-        }else if (localPathString.startsWith("s3:/")) {
+        } else if (localPathString.startsWith("s3:/")) {
           localPathString = localPathString.replace("s3:/", "")
         }
-        Seq(AwsBatchFileInput(s"$namePrefix-$index", remotePath.valueString, DefaultPathBuilder.get(localPathString), workingDisk))
+        Seq(
+          AwsBatchFileInput(
+            s"$namePrefix-$index",
+            remotePath.valueString,
+            DefaultPathBuilder.get(localPathString),
+            workingDisk
+          )
+        )
     }
-    
+
   }
 
-  /**
-    * Turns WomFiles into relative paths.  These paths are relative to the working disk.
+  /** Turns WomFiles into relative paths. These paths are relative to the
+    * working disk.
     *
     * relativeLocalizationPath("foo/bar.txt") -> "foo/bar.txt"
-    * relativeLocalizationPath("s3://some/bucket/foo.txt") -> "some/bucket/foo.txt"
+    * relativeLocalizationPath("s3://some/bucket/foo.txt") ->
+    * "some/bucket/foo.txt"
     */
   override protected def relativeLocalizationPath(file: WomFile): WomFile = {
     file.mapFile(value =>
       getPath(value) match {
         // for s3 paths :
         case Success(path: S3Path) =>
-          configuration.fileSystem match  {
-            case AWSBatchStorageSystems.s3 => 
-                URLDecoder.decode(path.pathWithoutScheme,"UTF-8")
-            case _ =>  
-                URLDecoder.decode(path.toString,"UTF-8")
+          configuration.fileSystem match {
+            case AWSBatchStorageSystems.s3 =>
+              URLDecoder.decode(path.pathWithoutScheme, "UTF-8")
+            case _ =>
+              URLDecoder.decode(path.toString, "UTF-8")
           }
         // non-s3 paths
-        case _ => 
-            URLDecoder.decode(value,"UTF-8")
+        case _ =>
+          URLDecoder.decode(value, "UTF-8")
       }
     )
   }
 
-  /**
-    * Generate a set of inputs based on a job description
-    * @param jobDescriptor the job descriptor from Cromwell
-    * @return the inputs derived from the descriptor
+  /** Generate a set of inputs based on a job description
+    * @param jobDescriptor
+    *   the job descriptor from Cromwell
+    * @return
+    *   the inputs derived from the descriptor
     */
-  private[aws] def generateAwsBatchInputs(jobDescriptor: BackendJobDescriptor): Set[AwsBatchInput] = {
-    val writeFunctionFiles = instantiatedCommand.createdFiles map { f => f.file.value.md5SumShort -> List(f) } toMap
+  private[aws] def generateAwsBatchInputs(
+      jobDescriptor: BackendJobDescriptor
+  ): Set[AwsBatchInput] = {
+    val writeFunctionFiles = instantiatedCommand.createdFiles map { f =>
+      f.file.value.md5SumShort -> List(f)
+    } toMap
 
-    val writeFunctionInputs = writeFunctionFiles flatMap {
-      case (name, files) => inputsFromWomFiles(name, files.map(_.file), files.map(localizationPath), jobDescriptor, false)
+    val writeFunctionInputs = writeFunctionFiles flatMap { case (name, files) =>
+      inputsFromWomFiles(
+        name,
+        files.map(_.file),
+        files.map(localizationPath),
+        jobDescriptor,
+        false
+      )
     }
 
     // Collect all WomFiles from inputs to the call.
-    val callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor.fullyQualifiedInputs safeMapValues {
-      womFile =>
+    val callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] =
+      jobDescriptor.fullyQualifiedInputs safeMapValues { womFile =>
         val arrays: Seq[WomArray] = womFile collectAsSeq {
           case womFile: WomFile =>
             val files: List[WomSingleFile] = DirectoryFunctions
               .listWomSingleFiles(womFile, callPaths.workflowPaths)
-              .toTry(s"Error getting single files for $womFile").get
+              .toTry(s"Error getting single files for $womFile")
+              .get
             WomArray(WomArrayType(WomSingleFileType), files)
         }
 
-        arrays.flatMap(_.value).collect {
-          case womFile: WomFile => womFile
+        arrays.flatMap(_.value).collect { case womFile: WomFile =>
+          womFile
         }
-    }
-    
-    val callInputInputs = callInputFiles flatMap {
-      case (name, files) => inputsFromWomFiles(name, files, files.map(relativeLocalizationPath), jobDescriptor, true)
+      }
+
+    val callInputInputs = callInputFiles flatMap { case (name, files) =>
+      inputsFromWomFiles(
+        name,
+        files,
+        files.map(relativeLocalizationPath),
+        jobDescriptor,
+        true
+      )
     }
     // this is a list : AwsBatchInput(name_in_wf, origin_such_as_s3, target_in_docker_relative, target_in_docker_disk[name mount] )
     val scriptInput: AwsBatchInput = AwsBatchFileInput(
@@ -316,71 +382,96 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     Set(scriptInput) ++ writeFunctionInputs ++ callInputInputs
   }
 
-  /**
-    * Given a path (relative or absolute), returns a (Path, AwsBatchVolume) tuple where the Path is
-    * relative to the Volume's mount point
+  /** Given a path (relative or absolute), returns a (Path, AwsBatchVolume)
+    * tuple where the Path is relative to the Volume's mount point
     *
-    * @throws Exception if the `path` does not live in one of the supplied `disks`
+    * @throws Exception
+    *   if the `path` does not live in one of the supplied `disks`
     */
-  private def relativePathAndVolume(path: String, disks: Seq[AwsBatchVolume] ): (Path, AwsBatchVolume) = {
+  private def relativePathAndVolume(
+      path: String,
+      disks: Seq[AwsBatchVolume]
+  ): (Path, AwsBatchVolume) = {
 
     def getAbsolutePath(path: Path) = {
       configuration.fileSystem match {
-        case AWSBatchStorageSystems.s3 => AwsBatchWorkingDisk.MountPoint.resolve(path)
+        case AWSBatchStorageSystems.s3 =>
+          AwsBatchWorkingDisk.MountPoint.resolve(path)
         case _ => AwsBatchWorkingDisk.MountPoint.resolve(path)
       }
     }
-    
+
     val absolutePath = DefaultPathBuilder.get(path) match {
       case p if !p.isAbsolute => getAbsolutePath(p)
-      case p => p
+      case p                  => p
     }
     disks.find(d => absolutePath.startsWith(d.mountPoint)) match {
       case Some(disk) => (disk.mountPoint.relativize(absolutePath), disk)
       case None =>
-        throw new Exception(s"Absolute path $path doesn't appear to be under any mount points: ${disks.map(_.toString).mkString(", ")}")
+        throw new Exception(
+          s"Absolute path $path doesn't appear to be under any mount points: ${disks.map(_.toString).mkString(", ")}"
+        )
     }
   }
 
-  /**
-    * Produces names with a length less than 128 characters possibly by producing a digest of the name
-    * @param referenceName the name to make safe
-    * @return the name or the MD5sum of that name if the name is >= 128 characters
+  /** Produces names with a length less than 128 characters possibly by
+    * producing a digest of the name
+    * @param referenceName
+    *   the name to make safe
+    * @return
+    *   the name or the MD5sum of that name if the name is >= 128 characters
     */
   private def makeSafeAwsBatchReferenceName(referenceName: String) = {
     if (referenceName.length <= 127) referenceName else referenceName.md5Sum
   }
 
-  private[aws] def generateAwsBatchOutputs(jobDescriptor: BackendJobDescriptor): Set[AwsBatchFileOutput] = {
+  private[aws] def generateAwsBatchOutputs(
+      jobDescriptor: BackendJobDescriptor
+  ): Set[AwsBatchFileOutput] = {
     import cats.syntax.validated._
     def evaluateFiles(output: OutputDefinition): List[WomFile] = {
       Try(
-        output.expression.evaluateFiles(jobDescriptor.localInputs, NoIoFunctionSet, output.womType).map(_.toList map { _.file })
+        output.expression
+          .evaluateFiles(
+            jobDescriptor.localInputs,
+            NoIoFunctionSet,
+            output.womType
+          )
+          .map(_.toList map { _.file })
       ).getOrElse(List.empty[WomFile].validNel)
-       .getOrElse(List.empty)
+        .getOrElse(List.empty)
     }
-    val womFileOutputs = jobDescriptor.taskCall.callable.outputs.flatMap(evaluateFiles) map relativeLocalizationPath
+    val womFileOutputs = jobDescriptor.taskCall.callable.outputs
+      .flatMap(evaluateFiles) map relativeLocalizationPath
     val outputs: Seq[AwsBatchFileOutput] = womFileOutputs.distinct flatMap {
       _.flattenFiles flatMap {
-        case unlistedDirectory: WomUnlistedDirectory => generateUnlistedDirectoryOutputs(unlistedDirectory)
-        case singleFile: WomSingleFile => generateAwsBatchSingleFileOutputs(singleFile)
+        case unlistedDirectory: WomUnlistedDirectory =>
+          generateUnlistedDirectoryOutputs(unlistedDirectory)
+        case singleFile: WomSingleFile =>
+          generateAwsBatchSingleFileOutputs(singleFile)
         case globFile: WomGlobFile => generateAwsBatchGlobFileOutputs(globFile)
       }
     }
 
-    val additionalGlobOutput = jobDescriptor.taskCall.callable.additionalGlob.toList.flatMap(generateAwsBatchGlobFileOutputs).toSet
-    
+    val additionalGlobOutput =
+      jobDescriptor.taskCall.callable.additionalGlob.toList
+        .flatMap(generateAwsBatchGlobFileOutputs)
+        .toSet
+
     outputs.toSet ++ additionalGlobOutput
   }
 
-
   // used by generateAwsBatchOutputs, could potentially move this def within that function
-  private def generateUnlistedDirectoryOutputs(womFile: WomUnlistedDirectory): List[AwsBatchFileOutput] = {
+  private def generateUnlistedDirectoryOutputs(
+      womFile: WomUnlistedDirectory
+  ): List[AwsBatchFileOutput] = {
     val directoryPath = womFile.value.ensureSlashed
     val directoryListFile = womFile.value.ensureUnslashed + ".list"
     val dirDestinationPath = callRootPath.resolve(directoryPath).pathAsString
-    val listDestinationPath = callRootPath.resolve(directoryListFile).pathAsString
-    val (_, directoryDisk) = relativePathAndVolume(womFile.value, runtimeAttributes.disks)
+    val listDestinationPath =
+      callRootPath.resolve(directoryListFile).pathAsString
+    val (_, directoryDisk) =
+      relativePathAndVolume(womFile.value, runtimeAttributes.disks)
 
     // We need both the collection directory and the collection list:
     List(
@@ -402,106 +493,172 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   }
 
   // used by generateAwsBatchOutputs, could potentially move this def within that function
-  private def generateAwsBatchSingleFileOutputs(womFile: WomSingleFile): List[AwsBatchFileOutput] = {
+  private def generateAwsBatchSingleFileOutputs(
+      womFile: WomSingleFile
+  ): List[AwsBatchFileOutput] = {
     // rewrite this to create more flexibility
-    // 
+    //
     val destination = configuration.fileSystem match {
-      case  AWSBatchStorageSystems.s3 =>  callRootPath.resolve(womFile.value.stripPrefix("/")).pathAsString
-      case _ => DefaultPathBuilder.get(womFile.valueString) match {
-        case p if !p.isAbsolute =>  callRootPath.resolve(womFile.value.stripPrefix("/")).pathAsString
-        case p => p.pathAsString
-      }
+      case AWSBatchStorageSystems.s3 =>
+        callRootPath.resolve(womFile.value.stripPrefix("/")).pathAsString
+      case _ =>
+        DefaultPathBuilder.get(womFile.valueString) match {
+          case p if !p.isAbsolute =>
+            callRootPath.resolve(womFile.value.stripPrefix("/")).pathAsString
+          case p => p.pathAsString
+        }
 
     }
-    val (relpath, disk) = relativePathAndVolume(womFile.value, runtimeAttributes.disks)
-    
-    val output = if (configuration.efsMntPoint.isDefined && 
-                     configuration.efsMntPoint.getOrElse("").equals(disk.toString.split(" ")(1)) &&
-                     ! runtimeAttributes.efsDelocalize) {
-            // name: String, s3key: String, local: Path, mount: AwsBatchVolume
-            AwsBatchFileOutput(makeSafeAwsBatchReferenceName(womFile.value), womFile.value, relpath, disk)
-        } else {
-            // if efs is not enabled, OR efs delocalization IS enabled, keep the s3 path as destination.
-            AwsBatchFileOutput(makeSafeAwsBatchReferenceName(womFile.value), URLDecoder.decode(destination,"UTF-8"), relpath, disk)
-        }
+    val (relpath, disk) =
+      relativePathAndVolume(womFile.value, runtimeAttributes.disks)
+
+    val output =
+      if (
+        configuration.efsMntPoint.isDefined &&
+        configuration.efsMntPoint
+          .getOrElse("")
+          .equals(disk.toString.split(" ")(1)) &&
+        !runtimeAttributes.efsDelocalize
+      ) {
+        // name: String, s3key: String, local: Path, mount: AwsBatchVolume
+        AwsBatchFileOutput(
+          makeSafeAwsBatchReferenceName(womFile.value),
+          womFile.value,
+          relpath,
+          disk
+        )
+      } else {
+        // if efs is not enabled, OR efs delocalization IS enabled, keep the s3 path as destination.
+        AwsBatchFileOutput(
+          makeSafeAwsBatchReferenceName(womFile.value),
+          URLDecoder.decode(destination, "UTF-8"),
+          relpath,
+          disk
+        )
+      }
     List(output)
   }
-  
+
   // get a unique glob name locations & paths.
   //  1. globName :md5 hash of local PATH and WF_ID
   //  2. globbedDir : local path of the directory being globbed.
   //  3. volume on which the globbed data is located (eg root, efs, ...)
   //  4. target path for delocalization for globDir
   //  5. target path for delocalization for globList
-  private def generateGlobPaths(womFile: WomGlobFile): (String, String, AwsBatchVolume,String, String) = {
+  private def generateGlobPaths(
+      womFile: WomGlobFile
+  ): (String, String, AwsBatchVolume, String, String) = {
     // add workflow id to hash for better conflict prevention
     val wfid = standardParams.jobDescriptor.toString.split(":")(0)
     val globName = GlobFunctions.globName(s"${womFile.value}-${wfid}")
     val globbedDir = Paths.get(womFile.value).getParent.toString
     // generalize folder and list file
-    val globDirectory = DefaultPathBuilder.get(globbedDir + "/." + globName + "/")
-    val globListFile = DefaultPathBuilder.get(globbedDir + "/." + globName + ".list")
+    val globDirectory =
+      DefaultPathBuilder.get(globbedDir + "/." + globName + "/")
+    val globListFile =
+      DefaultPathBuilder.get(globbedDir + "/." + globName + ".list")
 
     // locate the disk where the globbed data resides
-    val (_, globDirectoryDisk) = relativePathAndVolume(womFile.value, runtimeAttributes.disks)
+    val (_, globDirectoryDisk) =
+      relativePathAndVolume(womFile.value, runtimeAttributes.disks)
 
-    
-    val (globDirectoryDestinationPath, globListFileDestinationPath) = if (configuration.efsMntPoint.isDefined && 
-                     configuration.efsMntPoint.getOrElse("").equals(globDirectoryDisk.toString.split(" ")(1)) &&
-                     ! runtimeAttributes.efsDelocalize) {
-                        (globDirectory, globListFile)
-                     } else {
-                        // cannot resolve absolute paths : strip the leading '/'
-                        (callRootPath.resolve(globDirectory.toString.stripPrefix("/")).pathAsString, callRootPath.resolve(globListFile.toString.stripPrefix("/")).pathAsString)
-                     }
+    val (globDirectoryDestinationPath, globListFileDestinationPath) =
+      if (
+        configuration.efsMntPoint.isDefined &&
+        configuration.efsMntPoint
+          .getOrElse("")
+          .equals(globDirectoryDisk.toString.split(" ")(1)) &&
+        !runtimeAttributes.efsDelocalize
+      ) {
+        (globDirectory, globListFile)
+      } else {
+        // cannot resolve absolute paths : strip the leading '/'
+        (
+          callRootPath
+            .resolve(globDirectory.toString.stripPrefix("/"))
+            .pathAsString,
+          callRootPath
+            .resolve(globListFile.toString.stripPrefix("/"))
+            .pathAsString
+        )
+      }
     // return results
     return (
-        globName,
-        globbedDir,
-        globDirectoryDisk,
-        globDirectoryDestinationPath.toString,
-        globListFileDestinationPath.toString
+      globName,
+      globbedDir,
+      globDirectoryDisk,
+      globDirectoryDestinationPath.toString,
+      globListFileDestinationPath.toString
     )
-    
+
   }
   // used by generateAwsBatchOutputs, could potentially move this def within that function
-  private def generateAwsBatchGlobFileOutputs(womFile: WomGlobFile): List[AwsBatchFileOutput] = {
-    
-    val (globName, globbedDir, globDirectoryDisk, globDirectoryDestinationPath, globListFileDestinationPath) = generateGlobPaths(womFile)
-    val (relpathDir,_) = relativePathAndVolume(DefaultPathBuilder.get(globbedDir + "/." + globName + "/" + "*").toString,runtimeAttributes.disks)
-    val (relpathList,_) = relativePathAndVolume(DefaultPathBuilder.get(globbedDir + "/." + globName + ".list").toString,runtimeAttributes.disks)
+  private def generateAwsBatchGlobFileOutputs(
+      womFile: WomGlobFile
+  ): List[AwsBatchFileOutput] = {
+
+    val (
+      globName,
+      globbedDir,
+      globDirectoryDisk,
+      globDirectoryDestinationPath,
+      globListFileDestinationPath
+    ) = generateGlobPaths(womFile)
+    val (relpathDir, _) = relativePathAndVolume(
+      DefaultPathBuilder.get(globbedDir + "/." + globName + "/" + "*").toString,
+      runtimeAttributes.disks
+    )
+    val (relpathList, _) = relativePathAndVolume(
+      DefaultPathBuilder.get(globbedDir + "/." + globName + ".list").toString,
+      runtimeAttributes.disks
+    )
     // We need both the glob directory and the glob list:
     List(
       // The glob directory:.
-      AwsBatchFileOutput(DefaultPathBuilder.get(globbedDir.toString + "/." + globName + "/" + "*").toString,globDirectoryDestinationPath, relpathDir, globDirectoryDisk),
+      AwsBatchFileOutput(
+        DefaultPathBuilder
+          .get(globbedDir.toString + "/." + globName + "/" + "*")
+          .toString,
+        globDirectoryDestinationPath,
+        relpathDir,
+        globDirectoryDisk
+      ),
       // The glob list file:
-      AwsBatchFileOutput(DefaultPathBuilder.get(globbedDir.toString + "/." + globName + ".list").toString, globListFileDestinationPath, relpathList, globDirectoryDisk)
+      AwsBatchFileOutput(
+        DefaultPathBuilder
+          .get(globbedDir.toString + "/." + globName + ".list")
+          .toString,
+        globListFileDestinationPath,
+        relpathList,
+        globDirectoryDisk
+      )
     )
   }
 
-  override lazy val commandDirectory: Path = configuration.fileSystem match  {
+  override lazy val commandDirectory: Path = configuration.fileSystem match {
     case AWSBatchStorageSystems.s3 => AwsBatchWorkingDisk.MountPoint
-    case _ =>  jobPaths.callExecutionRoot
+    case _                         => jobPaths.callExecutionRoot
   }
 
   override def scriptPreamble: String = {
     configuration.fileSystem match {
-      case  AWSBatchStorageSystems.s3 => ""
-      case _ => ""
+      case AWSBatchStorageSystems.s3 => ""
+      case _                         => ""
     }
   }
 
   override def scriptClosure: String = {
     configuration.fileSystem match {
-      case  AWSBatchStorageSystems.s3 => ""
-      case _ => s"exit $$(head -n 1 $rcPath)"
+      case AWSBatchStorageSystems.s3 => ""
+      case _                         => s"exit $$(head -n 1 $rcPath)"
     }
   }
 
   override def globParentDirectory(womGlobFile: WomGlobFile): Path =
     configuration.fileSystem match {
-      case  AWSBatchStorageSystems.s3 =>
-        val (_, disk) = relativePathAndVolume(womGlobFile.value, runtimeAttributes.disks)
+      case AWSBatchStorageSystems.s3 =>
+        val (_, disk) =
+          relativePathAndVolume(womGlobFile.value, runtimeAttributes.disks)
         disk.mountPoint
       case _ => commandDirectory
     }
@@ -509,17 +666,18 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   override def isTerminal(runStatus: RunStatus): Boolean = {
     runStatus match {
       case _: TerminalRunStatus => true
-      case _ => false
+      case _                    => false
     }
   }
 
-  /**
-    * Asynchronously upload the command script to the script path
-    * @return a `Future` for the asynch operation
+  /** Asynchronously upload the command script to the script path
+    * @return
+    *   a `Future` for the asynch operation
     */
   def uploadScriptFile(): Future[Unit] = {
     commandScriptContents.fold(
-      errors => Future.failed(new RuntimeException(errors.toList.mkString(", "))),
+      errors =>
+        Future.failed(new RuntimeException(errors.toList.mkString(", "))),
       asyncIo.writeAsync(jobPaths.script, _, Seq.empty)
     )
   }
@@ -528,27 +686,48 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   override def executeAsync(): Future[ExecutionHandle] = {
 
     for {
-      //upload the command script
+      // upload the command script
       _ <- uploadScriptFile()
       completionPromise = Promise[SubmitJobResponse]()
-      //send a message to the Actor requesting a job submission
-      _ = backendSingletonActor ! SubmitAwsJobRequest(batchJob, attributes, completionPromise)
-      //the future response of the submit job request
+      // send a message to the Actor requesting a job submission
+      _ = backendSingletonActor ! SubmitAwsJobRequest(
+        batchJob,
+        attributes,
+        completionPromise
+      )
+      // the future response of the submit job request
       submitJobResponse <- completionPromise.future
-      //send a notify of status method to the Actor
-      _ = backendSingletonActor ! NotifyOfStatus(runtimeAttributes.queueArn, submitJobResponse.jobId, Option(Initializing))
-    } yield PendingExecutionHandle(jobDescriptor, StandardAsyncJob(submitJobResponse.jobId), Option(batchJob), previousState = None)
+      // send a notify of status method to the Actor
+      _ = backendSingletonActor ! NotifyOfStatus(
+        runtimeAttributes.queueArn,
+        submitJobResponse.jobId,
+        Option(Initializing)
+      )
+    } yield PendingExecutionHandle(
+      jobDescriptor,
+      StandardAsyncJob(submitJobResponse.jobId),
+      Option(batchJob),
+      previousState = None
+    )
   }
 
+  override def recoverAsync(jobId: StandardAsyncJob): Future[ExecutionHandle] =
+    reconnectAsync(jobId)
 
-  override def recoverAsync(jobId: StandardAsyncJob): Future[ExecutionHandle] =  reconnectAsync(jobId)
-
-  override def reconnectAsync(jobId: StandardAsyncJob): Future[ExecutionHandle] = {
-    val handle = PendingExecutionHandle[StandardAsyncJob, StandardAsyncRunInfo, StandardAsyncRunState](jobDescriptor, jobId, Option(batchJob), previousState = None)
+  override def reconnectAsync(
+      jobId: StandardAsyncJob
+  ): Future[ExecutionHandle] = {
+    val handle = PendingExecutionHandle[
+      StandardAsyncJob,
+      StandardAsyncRunInfo,
+      StandardAsyncRunState
+    ](jobDescriptor, jobId, Option(batchJob), previousState = None)
     Future.successful(handle)
   }
 
-  override def reconnectToAbortAsync(jobId: StandardAsyncJob): Future[ExecutionHandle] = {
+  override def reconnectToAbortAsync(
+      jobId: StandardAsyncJob
+  ): Future[ExecutionHandle] = {
     tryAbort(jobId)
     reconnectAsync(jobId)
   }
@@ -558,7 +737,9 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   // AWS Batch API to do this. The AwsBatchJob object in the PendingExecutionHandle
   // will have the actual status call, so our job here is simply to pull the
   // object out of the handle and execute the underlying status method
-  override def pollStatusAsync(handle: AwsBatchPendingExecutionHandle): Future[RunStatus] = {
+  override def pollStatusAsync(
+      handle: AwsBatchPendingExecutionHandle
+  ): Future[RunStatus] = {
     val jobId = handle.pendingJob.jobId
     val job = handle.runInfo match {
       case Some(actualJob) => actualJob
@@ -577,20 +758,25 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         jobLogger.debug("Having to fall back to AWS query for status")
         Future.fromTry(job.status(jobId))
       case other =>
-        val message = s"Programmer Error (please report this): Received an unexpected message from the OccasionalPollingActor: $other"
+        val message =
+          s"Programmer Error (please report this): Received an unexpected message from the OccasionalPollingActor: $other"
         jobLogger.error(message)
         Future.failed(new Exception(message) with NoStackTrace)
     }
 
     for {
-      quickAnswer <- backendSingletonActor ? WhatsMyStatus(runtimeAttributes.queueArn, jobId)
+      quickAnswer <- backendSingletonActor ? WhatsMyStatus(
+        runtimeAttributes.queueArn,
+        jobId
+      )
       guaranteedAnswer <- useQuickAnswerOrFallback(quickAnswer)
     } yield guaranteedAnswer
   }
 
-  override def handleExecutionResult(status: StandardAsyncRunState,
-                            oldHandle: StandardAsyncPendingExecutionHandle): Future[ExecutionHandle] = {
-    
+  override def handleExecutionResult(
+      status: StandardAsyncRunState,
+      oldHandle: StandardAsyncPendingExecutionHandle
+  ): Future[ExecutionHandle] = {
 
     // get path to sderr
     val stderr = jobPaths.standardPaths.error
@@ -600,201 +786,307 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       returnCodeAsString <- JobExitCode
       // Only check stderr size if we need to, otherwise this results in a lot of unnecessary I/O that
       // may fail due to race conditions on quickly-executing jobs.
-      stderrSize <- if (failOnStdErr) asyncIo.sizeAsync(stderr) else Future.successful(0L)
+      stderrSize <-
+        if (failOnStdErr) asyncIo.sizeAsync(stderr) else Future.successful(0L)
       retryWithMoreMemory <- memoryRetryRC(oldHandle.pendingJob)
     } yield (stderrSize, returnCodeAsString, retryWithMoreMemory)
 
     stderrSizeAndReturnCodeAndMemoryRetry flatMap {
       case (stderrSize, returnCodeAsString, retryWithMoreMemory) =>
         val tryReturnCodeAsInt = Try(returnCodeAsString.trim.toInt)
-        jobLogger.debug(s"Handling execution Result with status '${status.toString()}' and returnCode ${returnCodeAsString}")
+        jobLogger.debug(
+          s"Handling execution Result with status '${status.toString()}' and returnCode ${returnCodeAsString}"
+        )
         if (isDone(status)) {
           tryReturnCodeAsInt match {
             // stderr not empty : retry
-            case Success(returnCodeAsInt) if failOnStdErr && stderrSize.intValue > 0 =>
-              val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(StderrNonEmpty(jobDescriptor.key.tag, stderrSize, stderrAsOption), Option(returnCodeAsInt), None))
+            case Success(returnCodeAsInt)
+                if failOnStdErr && stderrSize.intValue > 0 =>
+              val executionHandle = Future.successful(
+                FailedNonRetryableExecutionHandle(
+                  StderrNonEmpty(
+                    jobDescriptor.key.tag,
+                    stderrSize,
+                    stderrAsOption
+                  ),
+                  Option(returnCodeAsInt),
+                  None
+                )
+              )
               retryElseFail(executionHandle)
-            // job was aborted (cancelled by user?) 
-            // on AWS OOM kill are code 137 : check retryWithMoreMemory here 
-            case Success(returnCodeAsInt) if isAbort(returnCodeAsInt) && !retryWithMoreMemory =>
-              jobLogger.debug(s"Job was aborted, code was : '${returnCodeAsString.stripLineEnd}'")
+            // job was aborted (cancelled by user?)
+            // on AWS OOM kill are code 137 : check retryWithMoreMemory here
+            case Success(returnCodeAsInt)
+                if isAbort(returnCodeAsInt) && !retryWithMoreMemory =>
+              jobLogger.debug(
+                s"Job was aborted, code was : '${returnCodeAsString.stripLineEnd}'"
+              )
               Future.successful(AbortedExecutionHandle)
             // if instance killed after RC.txt creation : edge case with status == Failed AND returnCode == [accepted values] => retry.
-            case Success(returnCodeAsInt) if status.toString() == "Failed" && continueOnReturnCode.continueFor(returnCodeAsInt) =>
-                jobLogger.debug(s"Suspected spot kill due to status/RC mismatch")
-                val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(UnExpectedStatus(jobDescriptor.key.tag, returnCodeAsInt, status.toString(), stderrAsOption), Option(returnCodeAsInt), None))
-                retryElseFail(executionHandle)
+            case Success(returnCodeAsInt)
+                if status.toString() == "Failed" && continueOnReturnCode
+                  .continueFor(returnCodeAsInt) =>
+              jobLogger.debug(s"Suspected spot kill due to status/RC mismatch")
+              val executionHandle = Future.successful(
+                FailedNonRetryableExecutionHandle(
+                  UnExpectedStatus(
+                    jobDescriptor.key.tag,
+                    returnCodeAsInt,
+                    status.toString(),
+                    stderrAsOption
+                  ),
+                  Option(returnCodeAsInt),
+                  None
+                )
+              )
+              retryElseFail(executionHandle)
             // job considered ok by accepted exit code
-            case Success(returnCodeAsInt) if continueOnReturnCode.continueFor(returnCodeAsInt) =>
+            case Success(returnCodeAsInt)
+                if continueOnReturnCode.continueFor(returnCodeAsInt) =>
               handleExecutionSuccess(status, oldHandle, returnCodeAsInt)
             // job failed on out-of-memory : retry
-            case Success(returnCodeAsInt) if retryWithMoreMemory  =>
-              jobLogger.info(s"Retrying job due to OOM with exit code : '${returnCodeAsString.stripLineEnd}' ")
-              val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(RetryWithMoreMemory(jobDescriptor.key.tag, stderrAsOption, memoryRetryErrorKeys, log), Option(returnCodeAsInt), None))
+            case Success(returnCodeAsInt) if retryWithMoreMemory =>
+              jobLogger.info(
+                s"Retrying job due to OOM with exit code : '${returnCodeAsString.stripLineEnd}' "
+              )
+              val executionHandle = Future.successful(
+                FailedNonRetryableExecutionHandle(
+                  RetryWithMoreMemory(
+                    jobDescriptor.key.tag,
+                    stderrAsOption,
+                    memoryRetryErrorKeys,
+                    log
+                  ),
+                  Option(returnCodeAsInt),
+                  None
+                )
+              )
               retryElseFail(executionHandle, retryWithMoreMemory)
             // unaccepted return code : retry.
             case Success(returnCodeAsInt) =>
-              jobLogger.debug(s"Retrying with wrong exit code : '${returnCodeAsString.stripLineEnd}'")
-              val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(WrongReturnCode(jobDescriptor.key.tag, returnCodeAsInt, stderrAsOption), Option(returnCodeAsInt), None))
+              jobLogger.debug(
+                s"Retrying with wrong exit code : '${returnCodeAsString.stripLineEnd}'"
+              )
+              val executionHandle = Future.successful(
+                FailedNonRetryableExecutionHandle(
+                  WrongReturnCode(
+                    jobDescriptor.key.tag,
+                    returnCodeAsInt,
+                    stderrAsOption
+                  ),
+                  Option(returnCodeAsInt),
+                  None
+                )
+              )
               retryElseFail(executionHandle)
             case Failure(_) =>
-              jobLogger.warn(s"General failure of job with exit code : '${returnCodeAsString.stripLineEnd}'")
-              Future.successful(FailedNonRetryableExecutionHandle(ReturnCodeIsNotAnInt(jobDescriptor.key.tag, returnCodeAsString, stderrAsOption), kvPairsToSave = None))
+              jobLogger.warn(
+                s"General failure of job with exit code : '${returnCodeAsString.stripLineEnd}'"
+              )
+              Future.successful(
+                FailedNonRetryableExecutionHandle(
+                  ReturnCodeIsNotAnInt(
+                    jobDescriptor.key.tag,
+                    returnCodeAsString,
+                    stderrAsOption
+                  ),
+                  kvPairsToSave = None
+                )
+              )
           }
         } else {
           tryReturnCodeAsInt match {
-            case Success(returnCodeAsInt) if retryWithMoreMemory && !continueOnReturnCode.continueFor(returnCodeAsInt) =>
-              jobLogger.debug(s"job not done but retrying already? : ${status.toString()}")
-              val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(RetryWithMoreMemory(jobDescriptor.key.tag, stderrAsOption, memoryRetryErrorKeys, log), Option(returnCodeAsInt), None))
+            case Success(returnCodeAsInt)
+                if retryWithMoreMemory && !continueOnReturnCode.continueFor(
+                  returnCodeAsInt
+                ) =>
+              jobLogger.debug(
+                s"job not done but retrying already? : ${status.toString()}"
+              )
+              val executionHandle = Future.successful(
+                FailedNonRetryableExecutionHandle(
+                  RetryWithMoreMemory(
+                    jobDescriptor.key.tag,
+                    stderrAsOption,
+                    memoryRetryErrorKeys,
+                    log
+                  ),
+                  Option(returnCodeAsInt),
+                  None
+                )
+              )
               retryElseFail(executionHandle, retryWithMoreMemory)
             case _ =>
-              val failureStatus = handleExecutionFailure(status, tryReturnCodeAsInt.toOption)
+              val failureStatus =
+                handleExecutionFailure(status, tryReturnCodeAsInt.toOption)
               retryElseFail(failureStatus)
           }
         }
-    } recoverWith {
-      case exception =>
-        if (isDone(status)) Future.successful(FailedNonRetryableExecutionHandle(exception, kvPairsToSave = None))
-        else {
-          val failureStatus = handleExecutionFailure(status, None)
-          retryElseFail(failureStatus)
-        }
+    } recoverWith { case exception =>
+      if (isDone(status))
+        Future.successful(
+          FailedNonRetryableExecutionHandle(exception, kvPairsToSave = None)
+        )
+      else {
+        val failureStatus = handleExecutionFailure(status, None)
+        retryElseFail(failureStatus)
+      }
     }
-  
-    
+
   }
-    
- 
-   // get the exit code of the job.
-   def JobExitCode: Future[String] = {
-     
-     // read if the file exists
-     def readRCFile(fileExists: Boolean): Future[String] = {
-       if (fileExists)
-         asyncIo.contentAsStringAsync(jobPaths.returnCode, None, failOnOverflow = false)
-       else {
-         jobLogger.warn("RC file not found in aws version. Setting job to failed.")
-         //Thread.sleep(300000)
-         Future("1")
-       }
-     }
-     //finally : assign the yielded variable
-     for {
-       fileExists <- asyncIo.existsAsync(jobPaths.returnCode)
-       jobRC <- readRCFile(fileExists)
-     } yield jobRC
-   }
-    
-   // new OOM detection 
-   def memoryRetryRC(job: StandardAsyncJob): Future[Boolean] = Future {
-      // STATUS LOGIC:
-      //   - success : container exit code is zero
-      //   - command failure: container exit code > 0, no statusReason in container
-      //   - OOM kill : container exit code > 0, statusReason contains "OutOfMemory" OR exit code == 137
-      //   - spot kill : no container exit code set. statusReason of ATTEMPT (not container) says "host EC2 (...) terminated"     
-      Log.debug(s"Looking for memoryRetry in job '${job.jobId}'")
-      val describeJobsResponse = batchClient.describeJobs(DescribeJobsRequest.builder.jobs(job.jobId).build)
-      val jobDetail = describeJobsResponse.jobs.get(0) //OrElse(throw new RuntimeException(s"Could not get job details for job '${job.jobId}'"))
-      val nrAttempts = jobDetail.attempts.size
-      // if job is terminated/cancelled before starting, there are no attempts. 
-      val lastattempt = 
-          try {
-              jobDetail.attempts.get(nrAttempts-1)
-          } catch {
-              case _ : Throwable => null
-          }
-      if (lastattempt == null ) {
-        Log.info(s"No attempts were made for job '${job.jobId}'. no memory-related retry needed.")
+
+  // get the exit code of the job.
+  def JobExitCode: Future[String] = {
+
+    // read if the file exists
+    def readRCFile(fileExists: Boolean): Future[String] = {
+      if (fileExists)
+        asyncIo.contentAsStringAsync(
+          jobPaths.returnCode,
+          None,
+          failOnOverflow = false
+        )
+      else {
+        jobLogger.warn(
+          "RC file not found in aws version. Setting job to failed."
+        )
+        // Thread.sleep(300000)
+        Future("1")
+      }
+    }
+    // finally : assign the yielded variable
+    for {
+      fileExists <- asyncIo.existsAsync(jobPaths.returnCode)
+      jobRC <- readRCFile(fileExists)
+    } yield jobRC
+  }
+
+  // new OOM detection
+  def memoryRetryRC(job: StandardAsyncJob): Future[Boolean] = Future {
+    // STATUS LOGIC:
+    //   - success : container exit code is zero
+    //   - command failure: container exit code > 0, no statusReason in container
+    //   - OOM kill : container exit code > 0, statusReason contains "OutOfMemory" OR exit code == 137
+    //   - spot kill : no container exit code set. statusReason of ATTEMPT (not container) says "host EC2 (...) terminated"
+    Log.debug(s"Looking for memoryRetry in job '${job.jobId}'")
+    val describeJobsResponse = batchClient.describeJobs(
+      DescribeJobsRequest.builder.jobs(job.jobId).build
+    )
+    val jobDetail = describeJobsResponse.jobs.get(
+      0
+    ) // OrElse(throw new RuntimeException(s"Could not get job details for job '${job.jobId}'"))
+    val nrAttempts = jobDetail.attempts.size
+    // if job is terminated/cancelled before starting, there are no attempts.
+    val lastattempt =
+      try {
+        jobDetail.attempts.get(nrAttempts - 1)
+      } catch {
+        case _: Throwable => null
+      }
+    if (lastattempt == null) {
+      Log.info(
+        s"No attempts were made for job '${job.jobId}'. no memory-related retry needed."
+      )
+      false
+    }
+    var containerRC =
+      try {
+        lastattempt.container.exitCode
+      } catch {
+        case _: Throwable => null
+      }
+    // if missing, set to failed.
+    if (containerRC == null) {
+      Log.debug(s"No RC found for job '${job.jobId}', most likely a spot kill")
+      containerRC = 1
+    }
+    // if not zero => get reason, else set retry to false.
+    containerRC.toString() match {
+      case "0" =>
+        Log.debug("container exit code was zero. job succeeded")
         false
-      }     
-      var containerRC = 
-          try {
-              lastattempt.container.exitCode
-          } catch {
-              case _ : Throwable => null
+      case "137" =>
+        Log.info(
+          "Job failed with Container status reason : 'OutOfMemory' (code:137)"
+        )
+        true
+      case _ =>
+        // failed job due to command errors (~ user errors) don't have a container exit reason.
+        val containerStatusReason: String = {
+          var lastReason = lastattempt.container.reason
+          // cast null to empty-string to prevent nullpointer exception.
+          if (lastReason == null || lastReason.isEmpty) {
+            lastReason = ""
+            log.debug("No exit reason found for container.")
+          } else {
+            Log.warn(
+              s"Job failed with Container status reason : '${lastReason}'"
+            )
           }
-      // if missing, set to failed.
-      if (containerRC == null ) {
-          Log.debug(s"No RC found for job '${job.jobId}', most likely a spot kill")
-          containerRC = 1
-      }
-      // if not zero => get reason, else set retry to false.
-      containerRC.toString() match {
-        case "0" => 
-            Log.debug("container exit code was zero. job succeeded")
-            false
-        case "137" => 
-            Log.info("Job failed with Container status reason : 'OutOfMemory' (code:137)")
-            true
-        case _ => 
-            // failed job due to command errors (~ user errors) don't have a container exit reason.
-            val containerStatusReason:String = {
-               var lastReason =  lastattempt.container.reason
-               // cast null to empty-string to prevent nullpointer exception.
-               if (lastReason == null || lastReason.isEmpty) {
-                   lastReason = ""
-                   log.debug("No exit reason found for container.")
-               } else {
-                   Log.warn(s"Job failed with Container status reason : '${lastReason}'")
-               }
-               lastReason
-            }
-            // check the list of OOM-keys against the exit reason.
-            val RetryMemoryKeys = memoryRetryErrorKeys.toList.flatten
-            val retry = RetryMemoryKeys.exists(containerStatusReason.contains)
-            Log.debug(s"Retry job based on provided keys : '${retry}'")
-            retry
-      }
-        
-        
-   }
+          lastReason
+        }
+        // check the list of OOM-keys against the exit reason.
+        val RetryMemoryKeys = memoryRetryErrorKeys.toList.flatten
+        val retry = RetryMemoryKeys.exists(containerStatusReason.contains)
+        Log.debug(s"Retry job based on provided keys : '${retry}'")
+        retry
+    }
 
-  
-
+  }
 
   // Despite being a "runtime" exception, BatchExceptions for 429 (too many requests) are *not* fatal:
   override def isFatal(throwable: Throwable): Boolean = throwable match {
     case be: BatchException => !be.getMessage.contains("Status Code: 429")
-    case _ => super.isFatal(throwable)
+    case _                  => super.isFatal(throwable)
   }
 
-  override lazy val startMetadataKeyValues: Map[String, Any] = super[AwsBatchJobCachingActorHelper].startMetadataKeyValues
+  override lazy val startMetadataKeyValues: Map[String, Any] =
+    super[AwsBatchJobCachingActorHelper].startMetadataKeyValues
 
-  //opportunity to send custom metadata when the run is in a terminal state, currently we don't
+  // opportunity to send custom metadata when the run is in a terminal state, currently we don't
   override def getTerminalMetadata(runStatus: RunStatus): Map[String, Any] = {
     runStatus match {
       case _: TerminalRunStatus => Map()
-      case unknown => throw new RuntimeException(s"Attempt to get terminal metadata from non terminal status: $unknown")
+      case unknown =>
+        throw new RuntimeException(
+          s"Attempt to get terminal metadata from non terminal status: $unknown"
+        )
     }
   }
   def hostAbsoluteFilePath(jobPaths: JobPaths, pathString: String): Path = {
 
-    val pathBuilders:List[PathBuilder]  = List(DefaultPathBuilder)
+    val pathBuilders: List[PathBuilder] = List(DefaultPathBuilder)
     val path = PathFactory.buildPath(pathString, pathBuilders)
     if (!path.isAbsolute)
       jobPaths.callExecutionRoot.resolve(path).toAbsolutePath
-    else if(jobPaths.isInExecution(path.pathAsString))
+    else if (jobPaths.isInExecution(path.pathAsString))
       jobPaths.hostPathFromContainerPath(path.pathAsString)
     else
       jobPaths.hostPathFromContainerInputs(path.pathAsString)
   }
 
   override def mapOutputWomFile(womFile: WomFile): WomFile = {
-    val wfile  =  configuration.fileSystem match {
-      case  AWSBatchStorageSystems.s3 =>
+    val wfile = configuration.fileSystem match {
+      case AWSBatchStorageSystems.s3 =>
         womFile
       case _ =>
         val hostPath = hostAbsoluteFilePath(jobPaths, womFile.valueString)
-        if (!hostPath.exists) throw new FileNotFoundException(s"Could not process output, file not found: ${hostPath.pathAsString}")
+        if (!hostPath.exists)
+          throw new FileNotFoundException(
+            s"Could not process output, file not found: ${hostPath.pathAsString}"
+          )
         womFile mapFile { _ => hostPath.pathAsString }
     }
     womFileToPath(generateAwsBatchOutputs(jobDescriptor))(wfile)
   }
 
-  private[aws] def womFileToPath(outputs: Set[AwsBatchFileOutput])(womFile: WomFile): WomFile = {
+  private[aws] def womFileToPath(
+      outputs: Set[AwsBatchFileOutput]
+  )(womFile: WomFile): WomFile = {
     womFile mapFile { path =>
       outputs collectFirst {
-        case output if output.name == makeSafeAwsBatchReferenceName(path) => output.s3key
+        case output if output.name == makeSafeAwsBatchReferenceName(path) =>
+          output.s3key
       } getOrElse path
     }
   }
@@ -803,7 +1095,9 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     runStatus match {
       case successStatus: RunStatus.Succeeded => successStatus.eventList
       case unknown => {
-            throw new RuntimeException(s"handleExecutionSuccess not called with RunStatus.Success. Instead got $unknown")
+        throw new RuntimeException(
+          s"handleExecutionSuccess not called with RunStatus.Success. Instead got $unknown"
+        )
       }
     }
   }
@@ -811,7 +1105,9 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   override def retryEvaluateOutputs(exception: Exception): Boolean = {
     exception match {
       case aggregated: CromwellAggregatedException =>
-        aggregated.throwables.collectFirst { case s: SocketTimeoutException => s }.isDefined
+        aggregated.throwables.collectFirst { case s: SocketTimeoutException =>
+          s
+        }.isDefined
       case _ => false
     }
   }
@@ -819,85 +1115,120 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   override def mapCommandLineWomFile(womFile: WomFile): WomFile = {
     womFile.mapFile(value =>
       getPath(value) match {
-        case Success(path: S3Path) => workingDisk.mountPoint.resolve(path.pathWithoutScheme).pathAsString
+        case Success(path: S3Path) =>
+          workingDisk.mountPoint.resolve(path.pathWithoutScheme).pathAsString
         case _ => value
       }
     )
   }
-    
-  override def handleExecutionSuccess(runStatus: StandardAsyncRunState,
-                             handle: StandardAsyncPendingExecutionHandle,
-                             returnCode: Int)(implicit ec: ExecutionContext): Future[ExecutionHandle] = {
+
+  override def handleExecutionSuccess(
+      runStatus: StandardAsyncRunState,
+      handle: StandardAsyncPendingExecutionHandle,
+      returnCode: Int
+  )(implicit ec: ExecutionContext): Future[ExecutionHandle] = {
     evaluateOutputs() map {
       case ValidJobOutputs(outputs) =>
         // Need to make sure the paths are up to date before sending the detritus back in the response
         updateJobPaths()
         // If instance is terminated while copying stdout/stderr : status is failed while jobs outputs are ok
-        //   => Retryable 
+        //   => Retryable
         if (runStatus.toString().equals("Failed")) {
-            jobLogger.warn("Got Failed RunStatus for success Execution")
+          jobLogger.warn("Got Failed RunStatus for success Execution")
 
-            val exception = new MessageAggregation {
-              override def exceptionContext: String = "Got Failed RunStatus for success Execution"
-              override def errorMessages: Iterable[String] = Array("Got Failed RunStatus for success Execution")
-            }
-            FailedNonRetryableExecutionHandle(exception, kvPairsToSave = None)
+          val exception = new MessageAggregation {
+            override def exceptionContext: String =
+              "Got Failed RunStatus for success Execution"
+            override def errorMessages: Iterable[String] =
+              Array("Got Failed RunStatus for success Execution")
+          }
+          FailedNonRetryableExecutionHandle(exception, kvPairsToSave = None)
         } else {
-            SuccessfulExecutionHandle(outputs, returnCode, jobPaths.detritusPaths, getTerminalEvents(runStatus))
+          SuccessfulExecutionHandle(
+            outputs,
+            returnCode,
+            jobPaths.detritusPaths,
+            getTerminalEvents(runStatus)
+          )
         }
       case InvalidJobOutputs(errors) =>
         val exception = new MessageAggregation {
-          override def exceptionContext: String = "Failed to evaluate job outputs"
+          override def exceptionContext: String =
+            "Failed to evaluate job outputs"
           override def errorMessages: Iterable[String] = errors.toList
         }
         FailedNonRetryableExecutionHandle(exception, kvPairsToSave = None)
-      case JobOutputsEvaluationException(exception: Exception) if retryEvaluateOutputsAggregated(exception) =>
+      case JobOutputsEvaluationException(exception: Exception)
+          if retryEvaluateOutputsAggregated(exception) =>
         // Return the execution handle in this case to retry the operation
         handle
-      case JobOutputsEvaluationException(ex) => FailedNonRetryableExecutionHandle(ex, kvPairsToSave = None)
+      case JobOutputsEvaluationException(ex) =>
+        FailedNonRetryableExecutionHandle(ex, kvPairsToSave = None)
     }
   }
 
-
-
   // overrides for globbing
-  /**
-    * Returns the shell scripting for linking a glob results file.
+  /** Returns the shell scripting for linking a glob results file.
     *
-    * @param globFile The glob.
-    * @return The shell scripting.
+    * @param globFile
+    *   The glob.
+    * @return
+    *   The shell scripting.
     */
   override def globScript(globFile: WomGlobFile): String = {
-    
-    val (globName, globbedDir, _, _, _) = generateGlobPaths(globFile) 
+    val (globDirectory, globList) =
+      if (
+        configuration.efsMntPoint.isDefined && globDirectory.startsWith(
+          configuration.efsMntPoint.getOrElse("")
+        )
+      ) {
+        val (globName, globbedDir, _, _, _) = generateGlobPaths(globFile)
+        (
+          globbedDir + "/." + globName + "/",
+          globbedDir + "/." + globName + ".list"
+        )
+      } else {
+        val parentDirectory = globParentDirectory(globFile)
+        val globDir = GlobFunctions.globName(globFile.value)
+        (parentDirectory./(globDir), parentDirectory./(s"$globDir.list"))
+      }
     val controlFileName = "cromwell_glob_control_file"
-    val absoluteGlobValue = commandDirectory.resolve(globFile.value).pathAsString
-    val globDirectory = globbedDir + "/." + globName + "/"
-    val globList = globbedDir + "/." + globName + ".list"
-    val globLinkCommand: String = (if (configuration.globLinkCommand.isDefined) {
-       "( " + configuration.globLinkCommand.getOrElse("").toString + " )"
+    val absoluteGlobValue =
+      commandDirectory.resolve(globFile.value).pathAsString
+    val globLinkCommand: String =
+      (if (configuration.globLinkCommand.isDefined) {
+         "( " + configuration.globLinkCommand.getOrElse("").toString + " )"
 
-    } else {
-        "( ln -L GLOB_PATTERN GLOB_DIRECTORY 2> /dev/null ) || ( ln GLOB_PATTERN GLOB_DIRECTORY )"
-    }).toString
-      .replaceAll("GLOB_PATTERN", absoluteGlobValue)
-      .replaceAll("GLOB_DIRECTORY", globDirectory)
-    // if on EFS : remove the globbing dir first, to remove leftover links from previous globs. 
-    val mkDirCmd : String = if (configuration.efsMntPoint.isDefined && globDirectory.startsWith(configuration.efsMntPoint.getOrElse(""))) {
+       } else {
+         "( ln -L GLOB_PATTERN GLOB_DIRECTORY 2> /dev/null ) || ( ln GLOB_PATTERN GLOB_DIRECTORY )"
+       }).toString
+        .replaceAll("GLOB_PATTERN", absoluteGlobValue)
+        .replaceAll("GLOB_DIRECTORY", globDirectory)
+    // if on EFS : remove the globbing dir first, to remove leftover links from previous globs.
+    val mkDirCmd: String =
+      if (
+        configuration.efsMntPoint.isDefined && globDirectory.startsWith(
+          configuration.efsMntPoint.getOrElse("")
+        )
+      ) {
         jobLogger.warn("Globbing on EFS has risks.")
-        jobLogger.warn(s"The globbing target (${globbedDir}/.${globName}/) will be overwritten when existing!")
-        jobLogger.warn("Consider keeping globbed outputs in the cromwell-root folder")
+        jobLogger.warn(
+          s"The globbing target (${globbedDir}/.${globName}/) will be overwritten when existing!"
+        )
+        jobLogger.warn(
+          "Consider keeping globbed outputs in the cromwell-root folder"
+        )
         s"rm -Rf $globDirectory $globList && mkdir"
-    } else {
+      } else {
         "mkdir"
-    }
- 
+      }
+
     val controlFileContent =
       """This file is used by Cromwell to allow for globs that would not match any file.
         |By its presence it works around the limitation of some backends that do not allow empty globs.
         |Regardless of the outcome of the glob, this file will not be part of the final list of globbed files.
       """.stripMargin
-    
+
     s"""|# make the directory which will keep the matching files
         |$mkDirCmd $globDirectory
         |

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -30,7 +30,6 @@
  */
 package cromwell.backend.impl.aws
 
-
 import java.security.MessageDigest
 import java.nio.file.attribute.PosixFilePermission
 
@@ -50,9 +49,17 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.batch.BatchClient
 import software.amazon.awssdk.services.batch.model._
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient
-import software.amazon.awssdk.services.cloudwatchlogs.model.{GetLogEventsRequest, OutputLogEvent}
+import software.amazon.awssdk.services.cloudwatchlogs.model.{
+  GetLogEventsRequest,
+  OutputLogEvent
+}
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest, NoSuchKeyException, PutObjectRequest}
+import software.amazon.awssdk.services.s3.model.{
+  GetObjectRequest,
+  HeadObjectRequest,
+  NoSuchKeyException,
+  PutObjectRequest
+}
 import wdl4s.parser.MemoryUnit
 
 import scala.jdk.CollectionConverters._
@@ -61,39 +68,46 @@ import scala.util.Try
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
-/**
-  *  The actual job for submission in AWS batch. `AwsBatchJob` is the primary interface to AWS Batch. It creates the
-  *  necessary `AwsBatchJobDefinition`, then submits the job using the SubmitJob API.
+/** The actual job for submission in AWS batch. `AwsBatchJob` is the primary
+  * interface to AWS Batch. It creates the necessary `AwsBatchJobDefinition`,
+  * then submits the job using the SubmitJob API.
   *
-  *  @constructor Create an `AwsBatchJob` object capable of submitting, aborting and monitoring itself
-  *  @param jobDescriptor the `BackendJobDescriptor` that is passed to the BackendWorkflowActor
-  *  @param runtimeAttributes runtime attributes class (which subsequently pulls from config)
-  *  @param commandLine command line to be passed to the job
-  *  @param commandScript the `commandLine` with additional commands to setup the context and localize/ de-localize files
+  * @constructor
+  *   Create an `AwsBatchJob` object capable of submitting, aborting and
+  *   monitoring itself
+  * @param jobDescriptor
+  *   the `BackendJobDescriptor` that is passed to the BackendWorkflowActor
+  * @param runtimeAttributes
+  *   runtime attributes class (which subsequently pulls from config)
+  * @param commandLine
+  *   command line to be passed to the job
+  * @param commandScript
+  *   the `commandLine` with additional commands to setup the context and
+  *   localize/ de-localize files
   */
-final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
-                             runtimeAttributes: AwsBatchRuntimeAttributes, // config or WDL/CWL
-                             commandLine: String, // WDL/CWL
-                             commandScript: String, // WDL/CWL
-                             dockerRc: String, // Calculated from StandardAsyncExecutionActor
-                             dockerStdout: String, // Calculated from StandardAsyncExecutionActor
-                             dockerStderr: String, // Calculated from StandardAsyncExecutionActor
-                             inputs: Set[AwsBatchInput],
-                             outputs: Set[AwsBatchFileOutput],
-                             jobPaths: JobPaths, // Based on config, calculated in Job Paths, key to all things outside container
-                             parameters: Seq[AwsBatchParameter],
-                             configRegion: Option[Region],
-                             optAwsAuthMode: Option[AwsAuthMode] = None,
-                             fsxMntPoint: Option[List[String]],
-                             efsMntPoint: Option[String],
-                             efsMakeMD5: Option[Boolean],
-                             efsDelocalize: Option[Boolean],
-                             tagResources: Option[Boolean]
-                            ) {
-
+final case class AwsBatchJob(
+    jobDescriptor: BackendJobDescriptor, // WDL/CWL
+    runtimeAttributes: AwsBatchRuntimeAttributes, // config or WDL/CWL
+    commandLine: String, // WDL/CWL
+    commandScript: String, // WDL/CWL
+    dockerRc: String, // Calculated from StandardAsyncExecutionActor
+    dockerStdout: String, // Calculated from StandardAsyncExecutionActor
+    dockerStderr: String, // Calculated from StandardAsyncExecutionActor
+    inputs: Set[AwsBatchInput],
+    outputs: Set[AwsBatchFileOutput],
+    jobPaths: JobPaths, // Based on config, calculated in Job Paths, key to all things outside container
+    parameters: Seq[AwsBatchParameter],
+    configRegion: Option[Region],
+    optAwsAuthMode: Option[AwsAuthMode] = None,
+    fsxMntPoint: Option[List[String]],
+    efsMntPoint: Option[String],
+    efsMakeMD5: Option[Boolean],
+    efsDelocalize: Option[Boolean],
+    tagResources: Option[Boolean]
+) {
 
   val Log: Logger = LoggerFactory.getLogger(AwsBatchJob.getClass)
-  //this will be the "folder" that scripts will live in (underneath the script bucket)
+  // this will be the "folder" that scripts will live in (underneath the script bucket)
   val scriptKeyPrefix = "scripts/"
 
   lazy val batchClient: BatchClient = {
@@ -110,69 +124,104 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
     configureClient(builder, optAwsAuthMode, configRegion)
   }
 
-  /**
-    * The goal of the reconfigured script is to do 3 things:
-    * 1. make a directory "working_dir" and replace all "/cromwell_root" with that
-    * 2. before the command line, insert the input copy command to stage input files
-    * 3. at the end of the script sync all content with the s3 bucket
+  /** The goal of the reconfigured script is to do 3 things:
+    *   1. make a directory "working_dir" and replace all "/cromwell_root" with
+    *      that 2. before the command line, insert the input copy command to
+    *      stage input files 3. at the end of the script sync all content with
+    *      the s3 bucket
     */
   lazy val reconfiguredScript: String = {
-    //this is the location of the aws cli mounted into the container by the ec2 launch template
+    // this is the location of the aws cli mounted into the container by the ec2 launch template
     val awsCmd = "/usr/local/aws-cli/v2/current/bin/aws"
-    //internal to the container, therefore not mounted
+    // internal to the container, therefore not mounted
     val workDir = "/tmp/scratch"
-    //working in a mount will cause collisions in long running workers
-    val replaced = commandScript.replace(AwsBatchWorkingDisk.MountPoint.pathAsString, workDir)
-    val insertionPoint = replaced.indexOf("\n", replaced.indexOf("#!")) +1 //just after the new line after the shebang!
+    // working in a mount will cause collisions in long running workers
+    val replaced = commandScript.replace(
+      AwsBatchWorkingDisk.MountPoint.pathAsString,
+      workDir
+    )
+    val insertionPoint =
+      replaced.indexOf(
+        "\n",
+        replaced.indexOf("#!")
+      ) + 1 // just after the new line after the shebang!
     // load the config
-    val conf : Config = ConfigFactory.load();
+    val conf: Config = ConfigFactory.load();
 
     /* generate a series of s3 copy statements to copy any s3 files into the container. */
-    val inputCopyCommand = inputs.map {
-      case input: AwsBatchFileInput if input.s3key.startsWith("s3://") && input.s3key.endsWith(".tmp") =>
-        //we are localizing a tmp file which may contain workdirectory paths that need to be reconfigured
-        s"""
+    val inputCopyCommand = inputs
+      .map {
+        case input: AwsBatchFileInput
+            if input.s3key
+              .startsWith("s3://") && input.s3key.endsWith(".tmp") =>
+          // we are localizing a tmp file which may contain workdirectory paths that need to be reconfigured
+          s"""
            |_s3_localize_with_retry "${input.s3key}" "$workDir/${input.local}"
            |sed -i 's#${AwsBatchWorkingDisk.MountPoint.pathAsString}#$workDir#g' "$workDir/${input.local}"
            |""".stripMargin
 
-      case input: AwsBatchFileInput if input.s3key.startsWith("s3://") => 
-        // regular s3 objects : download to working dir.
-        s"""_s3_localize_with_retry "${input.s3key}" "${input.mount.mountPoint.pathAsString}/${input.local}" """.stripMargin
-          .replace(AwsBatchWorkingDisk.MountPoint.pathAsString, workDir)
+        case input: AwsBatchFileInput if input.s3key.startsWith("s3://") =>
+          // regular s3 objects : download to working dir.
+          s"""_s3_localize_with_retry "${input.s3key}" "${input.mount.mountPoint.pathAsString}/${input.local}" """.stripMargin
+            .replace(AwsBatchWorkingDisk.MountPoint.pathAsString, workDir)
 
-      case input: AwsBatchFileInput if efsMntPoint.isDefined && input.s3key.startsWith(efsMntPoint.get) =>  
-        // EFS located file : test for presence on provided path.
-        Log.debug("EFS input file detected: "+ input.s3key + " / "+ input.local.pathAsString)
-        s"""test -e "${input.s3key}" || (echo 'input file: ${input.s3key} does not exist' && LOCALIZATION_FAILED=1)""".stripMargin
-      
-      case input: AwsBatchFileInput => 
-        // an entry in 'disks' => keep mount as it is.. 
-        //here we don't need a copy command but the centaurTests expect us to verify the existence of the file
-        //val filePath = s"${input.mount.mountPoint.pathAsString}/${input.local.pathAsString}"
-        //  .replace(AwsBatchWorkingDisk.MountPoint.pathAsString, workDir)
-        val filePath = input.local.pathAsString
-        Log.debug("input entry in disks detected "+ input.s3key + " / "+ input.local.pathAsString)
-        s"""test -e "$filePath" || (echo 'input file: $filePath does not exist' && LOCALIZATION_FAILED=1)""".stripMargin
-      
-      case _ => ""
-    }.toList.mkString("\n")
+        case input: AwsBatchFileInput
+            if efsMntPoint.isDefined && input.s3key.startsWith(
+              efsMntPoint.get
+            ) =>
+          // EFS located file : test for presence on provided path.
+          Log.debug(
+            "EFS input file detected: " + input.s3key + " / " + input.local.pathAsString
+          )
+          s"""test -e "${input.s3key}" || (echo 'input file: ${input.s3key} does not exist' && LOCALIZATION_FAILED=1)""".stripMargin
+
+        case input: AwsBatchFileInput =>
+          // an entry in 'disks' => keep mount as it is..
+          // here we don't need a copy command but the centaurTests expect us to verify the existence of the file
+          // val filePath = s"${input.mount.mountPoint.pathAsString}/${input.local.pathAsString}"
+          //  .replace(AwsBatchWorkingDisk.MountPoint.pathAsString, workDir)
+          val filePath = input.local.pathAsString
+          Log.debug(
+            "input entry in disks detected " + input.s3key + " / " + input.local.pathAsString
+          )
+          s"""test -e "$filePath" || (echo 'input file: $filePath does not exist' && LOCALIZATION_FAILED=1)""".stripMargin
+
+        case _ => ""
+      }
+      .toList
+      .mkString("\n")
 
     // get multipart threshold from config.
-    val mp_threshold : Long = if (conf.hasPath("engine.filesystems.s3.MultipartThreshold") ) conf.getMemorySize("engine.filesystems.s3.MultipartThreshold").toBytes() else 5L * 1024L * 1024L * 1024L; 
+    val mp_threshold: Long =
+      if (conf.hasPath("engine.filesystems.s3.MultipartThreshold"))
+        conf.getMemorySize("engine.filesystems.s3.MultipartThreshold").toBytes()
+      else 5L * 1024L * 1024L * 1024L;
     Log.debug(s"MultiPart Threshold for delocalizing is $mp_threshold")
 
     // prepare tags, strip invalid characters
     val invalidCharsPattern = "[^a-zA-Z0-9_.:/=+-@]+".r
-    Log.debug(s"root workflow id: ${jobDescriptor.workflowDescriptor.rootWorkflowId.toString}")
-    Log.debug(s"root workflow name: ${jobDescriptor.workflowDescriptor.rootWorkflow.name.toString}")
-    
-    
-    val workflowId = invalidCharsPattern.replaceAllIn(jobDescriptor.workflowDescriptor.rootWorkflowId.toString,"_")
-    val workflowName = invalidCharsPattern.replaceAllIn(jobDescriptor.workflowDescriptor.rootWorkflow.name.toString,"_")
-    val taskId = invalidCharsPattern.replaceAllIn(jobDescriptor.key.call.fullyQualifiedName + "-" + jobDescriptor.key.index + "-" + jobDescriptor.key.attempt,"_")
-    val doTagging = tagResources.getOrElse(false) // development : always tag resources.
-    //val tags: Map[String,String] = Map("cromwell-workflow-name" -> workflowName, "cromwell-workflow-id" -> workflowId, "cromwell-task-id" -> taskId)
+    Log.debug(
+      s"root workflow id: ${jobDescriptor.workflowDescriptor.rootWorkflowId.toString}"
+    )
+    Log.debug(
+      s"root workflow name: ${jobDescriptor.workflowDescriptor.rootWorkflow.name.toString}"
+    )
+
+    val workflowId = invalidCharsPattern.replaceAllIn(
+      jobDescriptor.workflowDescriptor.rootWorkflowId.toString,
+      "_"
+    )
+    val workflowName = invalidCharsPattern.replaceAllIn(
+      jobDescriptor.workflowDescriptor.rootWorkflow.name.toString,
+      "_"
+    )
+    val taskId = invalidCharsPattern.replaceAllIn(
+      jobDescriptor.key.call.fullyQualifiedName + "-" + jobDescriptor.key.index + "-" + jobDescriptor.key.attempt,
+      "_"
+    )
+    val doTagging =
+      tagResources.getOrElse(false) // development : always tag resources.
+    // val tags: Map[String,String] = Map("cromwell-workflow-name" -> workflowName, "cromwell-workflow-id" -> workflowId, "cromwell-task-id" -> taskId)
     // this goes at the start of the script after the #!
     val preamble =
       s"""
@@ -373,39 +422,51 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |set +e
          |}
          |""".stripMargin
-    
+
     // the paths of the stdOut and stdErr
     val stdOut = dockerStdout.replace("/cromwell_root", workDir)
     val stdErr = dockerStderr.replace("/cromwell_root", workDir)
 
-    //generate a series of s3 commands to delocalize artifacts from the container to storage at the end of the task
-    val outputCopyCommand = outputs.map {
-      // local is relative path, no mountpoint disk in front.
-      case output: AwsBatchFileOutput if output.local.pathAsString.contains("*") => "" //filter out globs
-      case output: AwsBatchFileOutput if output.s3key.endsWith(".list") && output.s3key.contains("glob-") =>
-        Log.debug("Globbing  : check for EFS settings.")
-        val s3GlobOutDirectory = output.s3key.replace(".list", "")
-        // glob paths are not generated with 127 char limit, using generateGlobPaths(). name can be used safely 
-        val globDirectory = output.name.replace(".list", "")
-        /*
-         * Need to process this list and de-localize each file if the list file actually exists
-         * if it doesn't exist then 'touch' it so that it can be copied otherwise later steps will get upset
-         * about the missing file
-         */
-        if ( efsMntPoint.isDefined && output.mount.mountPoint.pathAsString == efsMntPoint.get ) {
-           Log.debug("EFS glob output file detected: "+ output.s3key + s" / ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}")
-           val test_cmd = if (efsDelocalize.isDefined && efsDelocalize.getOrElse(false)) {
-                    Log.debug("delocalization on EFS is enabled")
-                    Log.debug(s"Delocalizing $globDirectory to $s3GlobOutDirectory\n")
-                    s"""
+    // generate a series of s3 commands to delocalize artifacts from the container to storage at the end of the task
+    val outputCopyCommand = outputs
+      .map {
+        // local is relative path, no mountpoint disk in front.
+        case output: AwsBatchFileOutput
+            if output.local.pathAsString.contains("*") =>
+          "" // filter out globs
+        case output: AwsBatchFileOutput
+            if output.s3key
+              .endsWith(".list") && output.s3key.contains("glob-") =>
+          Log.debug("Globbing  : check for EFS settings.")
+          val s3GlobOutDirectory = output.s3key.replace(".list", "")
+          // glob paths are not generated with 127 char limit, using generateGlobPaths(). name can be used safely
+          val globDirectory = output.name.replace(".list", "")
+          /*
+           * Need to process this list and de-localize each file if the list file actually exists
+           * if it doesn't exist then 'touch' it so that it can be copied otherwise later steps will get upset
+           * about the missing file
+           */
+          if (
+            efsMntPoint.isDefined && output.mount.mountPoint.pathAsString == efsMntPoint.get
+          ) {
+            Log.debug(
+              "EFS glob output file detected: " + output.s3key + s" / ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}"
+            )
+            val test_cmd =
+              if (efsDelocalize.isDefined && efsDelocalize.getOrElse(false)) {
+                Log.debug("delocalization on EFS is enabled")
+                Log.debug(
+                  s"Delocalizing $globDirectory to $s3GlobOutDirectory\n"
+                )
+                s"""
                         |touch "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}"
                         |_s3_delocalize_with_retry "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" "${output.s3key}"
                         |if [ -e $globDirectory ]; then _s3_delocalize_with_retry "$globDirectory" "$s3GlobOutDirectory" ; fi
                         |""".stripMargin
-                } else {
-                    
-                    // check file for existence
-                    s"""
+              } else {
+
+                // check file for existence
+                s"""
                         |# test the glob list
                         |test -e "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" || (echo 'output file: ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} does not exist' && DELOCALIZATION_FAILED=1)
                         |# test individual files.
@@ -416,12 +477,13 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
                         |done
                         |IFS="$$SAVEIFS"
                         |"""
-                }
-           // need to make md5sum? 
-           val md5_cmd = if (efsMakeMD5.isDefined && efsMakeMD5.getOrElse(false)) {
-                    Log.debug("Add cmd to create MD5 sibling.")
-                    // this does NOT regenerate the md5 in case the file is overwritten ! 
-                    s"""
+              }
+            // need to make md5sum?
+            val md5_cmd =
+              if (efsMakeMD5.isDefined && efsMakeMD5.getOrElse(false)) {
+                Log.debug("Add cmd to create MD5 sibling.")
+                // this does NOT regenerate the md5 in case the file is overwritten !
+                s"""
                         |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]] ; then 
                         |   # the glob list
                         |   md5sum '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' > '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || (echo 'Could not generate ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' && DELOCALIZATION_FAILED=1 ); 
@@ -431,75 +493,85 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
                         |   cat "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" | xargs -I% -P${runtimeAttributes.cpu.##.toString} bash -c "md5sum ${globDirectory}/% > ${globDirectory}/%.md5"
                         |fi
                         |IFS="$$SAVEIFS"
-                        |""".stripMargin 
-                } 
-           // return combined result
-           s"""
+                        |""".stripMargin
+              }
+            // return combined result
+            s"""
           |${test_cmd}
           |${md5_cmd}
           | """.stripMargin
-        } else {
-          // default delocalization command.
-          Log.debug(s"Delocalize from ${output.name} to ${output.s3key}\n")
-          s"""
+          } else {
+            // default delocalization command.
+            Log.debug(s"Delocalize from ${output.name} to ${output.s3key}\n")
+            s"""
              |touch "${output.name}"
              |_s3_delocalize_with_retry "${output.name}" "${output.s3key}"
              |if [ -e "$globDirectory" ]; then _s3_delocalize_with_retry "$globDirectory" "$s3GlobOutDirectory" ; fi""".stripMargin
-        }
+          }
 
-      // files on /cromwell/ working dir must be delocalized
-      case output: AwsBatchFileOutput if output.s3key.startsWith("s3://") && output.mount.mountPoint.pathAsString == AwsBatchWorkingDisk.MountPoint.pathAsString =>
-        //output is on working disk mount
-        Log.debug("output Data on working disk mount" + output.local.pathAsString)
-        s"""_s3_delocalize_with_retry "$workDir/${output.local.pathAsString}" "${output.s3key}" """.stripMargin
+        // files on /cromwell/ working dir must be delocalized
+        case output: AwsBatchFileOutput
+            if output.s3key.startsWith(
+              "s3://"
+            ) && output.mount.mountPoint.pathAsString == AwsBatchWorkingDisk.MountPoint.pathAsString =>
+          // output is on working disk mount
+          Log.debug(
+            "output Data on working disk mount" + output.local.pathAsString
+          )
+          s"""_s3_delocalize_with_retry "$workDir/${output.local.pathAsString}" "${output.s3key}" """.stripMargin
 
-      // file(name (full path), s3key (delocalized path), local (file basename), mount (disk details))
-      // files on EFS mounts are optionally delocalized.
-      case output: AwsBatchFileOutput if efsMntPoint.isDefined && output.mount.mountPoint.pathAsString == efsMntPoint.get =>
-        Log.debug("EFS output file detected: "+ output.s3key + s" / ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}")
-        // EFS located file : test existence or delocalize.
-        var test_cmd = ""
-        if (efsDelocalize.isDefined && efsDelocalize.getOrElse(false)) {
+        // file(name (full path), s3key (delocalized path), local (file basename), mount (disk details))
+        // files on EFS mounts are optionally delocalized.
+        case output: AwsBatchFileOutput
+            if efsMntPoint.isDefined && output.mount.mountPoint.pathAsString == efsMntPoint.get =>
+          Log.debug(
+            "EFS output file detected: " + output.s3key + s" / ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}"
+          )
+          // EFS located file : test existence or delocalize.
+          var test_cmd = ""
+          if (efsDelocalize.isDefined && efsDelocalize.getOrElse(false)) {
             Log.debug("efs-delocalization enabled")
-            test_cmd = s"""_s3_delocalize_with_retry "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" "${output.s3key}" """.stripMargin
-        } else {
+            test_cmd =
+              s"""_s3_delocalize_with_retry "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" "${output.s3key}" """.stripMargin
+          } else {
             Log.debug("efs-delocalization disabled")
             // check file for existence
-            test_cmd = s"""test -e "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" || (echo 'output file: ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} does not exist' && DELOCALIZATION_FAILED=1)""".stripMargin
-        }
-        // need to make md5sum?
-        var md5_cmd = ""
-        if (efsMakeMD5.isDefined && efsMakeMD5.getOrElse(false)) {
+            test_cmd =
+              s"""test -e "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" || (echo 'output file: ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString} does not exist' && DELOCALIZATION_FAILED=1)""".stripMargin
+          }
+          // need to make md5sum?
+          var md5_cmd = ""
+          if (efsMakeMD5.isDefined && efsMakeMD5.getOrElse(false)) {
             Log.debug("Add cmd to create MD5 sibling.")
             md5_cmd = s"""
                             |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]] ; then 
                             |   md5sum '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' > '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || (echo 'Could not generate ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' && DELOCALIZATION_FAILED=1 ); 
                             |fi
                             |""".stripMargin
-        } else {
+          } else {
             md5_cmd = ""
-        }
-        // return combined result
-        s"""
+          }
+          // return combined result
+          s"""
           |${test_cmd}
           |${md5_cmd}
           | """.stripMargin
 
-      case output: AwsBatchFileOutput =>
-        //output on a different mount
-        Log.debug("output data on other mount")
-        Log.debug(output.toString)
-        s"""_s3_delocalize_with_retry "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" "${output.s3key}" """.stripMargin
-      case _ => ""
-    }.mkString("\n") + "\n" +
+        case output: AwsBatchFileOutput =>
+          // output on a different mount
+          Log.debug("output data on other mount")
+          Log.debug(output.toString)
+          s"""_s3_delocalize_with_retry "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" "${output.s3key}" """.stripMargin
+        case _ => ""
+      }
+      .mkString("\n") + "\n" +
       s"""
          |if [ -f "$workDir/${jobPaths.returnCodeFilename}" ]; then _s3_delocalize_with_retry "$workDir/${jobPaths.returnCodeFilename}" "${jobPaths.callRoot.pathAsString}/${jobPaths.returnCodeFilename}" ; fi
          |if [ -f "$stdErr" ]; then _s3_delocalize_with_retry "$stdErr" "${jobPaths.standardPaths.error.pathAsString}"; fi
          |if [ -f "$stdOut" ]; then _s3_delocalize_with_retry "$stdOut" "${jobPaths.standardPaths.output.pathAsString}"; fi
          |""".stripMargin
 
-
-    //insert the preamble at the insertion point and the postscript copy command at the end
+    // insert the preamble at the insertion point and the postscript copy command at the end
     replaced.patch(insertionPoint, preamble, 0) +
       s"""
          |{
@@ -527,70 +599,126 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |}
          |""".stripMargin
   }
-  private def batch_file_s3_url(scriptBucketName: String, scriptKeyPrefix: String, scriptKey: String): String  = runtimeAttributes.fileSystem match {
-       case AWSBatchStorageSystems.s3  => s"s3://${runtimeAttributes.scriptS3BucketName}/$scriptKeyPrefix$scriptKey"
-       case _ => ""
+  private def batch_file_s3_url(
+      scriptBucketName: String,
+      scriptKeyPrefix: String,
+      scriptKey: String
+  ): String = runtimeAttributes.fileSystem match {
+    case AWSBatchStorageSystems.s3 =>
+      s"s3://${runtimeAttributes.scriptS3BucketName}/$scriptKeyPrefix$scriptKey"
+    case _ => ""
   }
 
-  private def generateEnvironmentKVPairs(scriptBucketName: String, scriptKeyPrefix: String, scriptKey: String): List[KeyValuePair] = {
+  private def generateEnvironmentKVPairs(
+      scriptBucketName: String,
+      scriptKeyPrefix: String,
+      scriptKey: String
+  ): List[KeyValuePair] = {
     List(
       buildKVPair("BATCH_FILE_TYPE", "script"),
-      buildKVPair("BATCH_FILE_S3_URL",batch_file_s3_url(scriptBucketName,scriptKeyPrefix,scriptKey)))
+      buildKVPair(
+        "BATCH_FILE_S3_URL",
+        batch_file_s3_url(scriptBucketName, scriptKeyPrefix, scriptKey)
+      )
+    )
   }
 
-  def submitJob[F[_]]()( implicit timer: Timer[F], async: Async[F]): Aws[F, SubmitJobResponse] = {
+  def submitJob[F[_]]()(implicit
+      timer: Timer[F],
+      async: Async[F]
+  ): Aws[F, SubmitJobResponse] = {
 
-    val taskId = jobDescriptor.key.call.fullyQualifiedName + "-" + jobDescriptor.key.index + "-" + jobDescriptor.key.attempt
+    val taskId =
+      jobDescriptor.key.call.fullyQualifiedName + "-" + jobDescriptor.key.index + "-" + jobDescriptor.key.attempt
 
-    //find or create the script in s3 to execute for s3 fileSystem
-    val scriptKey =  runtimeAttributes.fileSystem match {
-       case AWSBatchStorageSystems.s3  =>  findOrCreateS3Script(reconfiguredScript, runtimeAttributes.scriptS3BucketName)
-       case _ => ""
+    // find or create the script in s3 to execute for s3 fileSystem
+    val scriptKey = runtimeAttributes.fileSystem match {
+      case AWSBatchStorageSystems.s3 =>
+        findOrCreateS3Script(
+          reconfiguredScript,
+          runtimeAttributes.scriptS3BucketName
+        )
+      case _ => ""
     }
 
-    if(runtimeAttributes.fileSystem == AWSBatchStorageSystems.s3) {
-       val regex = "s3://([^/]*)/(.*)".r
-       val regex(bucketName, key) = jobPaths.callExecutionRoot.toString
-       writeReconfiguredScriptForAudit(reconfiguredScript, bucketName, key+"/reconfigured-script.sh")
-    }else{
+    if (runtimeAttributes.fileSystem == AWSBatchStorageSystems.s3) {
+      val regex = "s3://([^/]*)/(.*)".r
+      val regex(bucketName, key) = jobPaths.callExecutionRoot.toString
+      writeReconfiguredScriptForAudit(
+        reconfiguredScript,
+        bucketName,
+        key + "/reconfigured-script.sh"
+      )
+    } else {
       jobPaths.script.addPermission(PosixFilePermission.OTHERS_EXECUTE)
     }
 
-
     val batch_script = runtimeAttributes.fileSystem match {
-       case AWSBatchStorageSystems.s3  => s"s3://${runtimeAttributes.scriptS3BucketName}/$scriptKeyPrefix$scriptKey"
-       case _  => commandScript
+      case AWSBatchStorageSystems.s3 =>
+        s"s3://${runtimeAttributes.scriptS3BucketName}/$scriptKeyPrefix$scriptKey"
+      case _ => commandScript
     }
 
-    //calls the client to submit the job
-    def callClient(definitionArn: String, awsBatchAttributes: AwsBatchAttributes): Aws[F, SubmitJobResponse] = {
+    // calls the client to submit the job
+    def callClient(
+        definitionArn: String,
+        awsBatchAttributes: AwsBatchAttributes
+    ): Aws[F, SubmitJobResponse] = {
 
       val workflowId = jobDescriptor.workflowDescriptor.id.toString
       val workflowName = jobDescriptor.workflowDescriptor.callable.name.toString
-      val rootworkflowId = jobDescriptor.workflowDescriptor.rootWorkflowId.toString
-      Log.debug(s"Submitting taskId: $taskId, job definition : $definitionArn, script: $batch_script")
-      Log.info(s"Submitting taskId: $rootworkflowId::$taskId, script: $batch_script")
-      
-      //provide job environment variables, vcpu and memory
+      val rootworkflowId =
+        jobDescriptor.workflowDescriptor.rootWorkflowId.toString
+      Log.debug(
+        s"Submitting taskId: $taskId, job definition : $definitionArn, script: $batch_script"
+      )
+      Log.info(
+        s"Submitting taskId: $rootworkflowId::$taskId, script: $batch_script"
+      )
+
+      // provide job environment variables, vcpu and memory
       var resourceRequirements: Seq[ResourceRequirement] = Seq(
-        ResourceRequirement.builder().`type`(ResourceType.VCPU).value(runtimeAttributes.cpu.##.toString).build(),
-        ResourceRequirement.builder().`type`(ResourceType.MEMORY).value(runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString).build()
+        ResourceRequirement
+          .builder()
+          .`type`(ResourceType.VCPU)
+          .value(runtimeAttributes.cpu.##.toString)
+          .build(),
+        ResourceRequirement
+          .builder()
+          .`type`(ResourceType.MEMORY)
+          .value(
+            runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString
+          )
+          .build()
       )
 
       if (runtimeAttributes.gpuCount > 0) {
-        val gpuRequirement = ResourceRequirement.builder().`type`(ResourceType.GPU).value(runtimeAttributes.gpuCount.toString)
+        val gpuRequirement = ResourceRequirement
+          .builder()
+          .`type`(ResourceType.GPU)
+          .value(runtimeAttributes.gpuCount.toString)
         resourceRequirements = resourceRequirements :+ gpuRequirement.build()
       }
-          
+
       // prepare the job request
-      var submitJobRequest = SubmitJobRequest.builder()
+      var submitJobRequest = SubmitJobRequest
+        .builder()
         .jobName(sanitize(jobDescriptor.taskCall.fullyQualifiedName))
-        .parameters(parameters.collect({ case i: AwsBatchInput => i.toStringString }).toMap.asJava)
-        //provide job environment variables, vcpu and memory
+        .parameters(
+          parameters
+            .collect({ case i: AwsBatchInput => i.toStringString })
+            .toMap
+            .asJava
+        )
+        // provide job environment variables, vcpu and memory
         .containerOverrides(
           ContainerOverrides.builder
             .environment(
-              generateEnvironmentKVPairs(runtimeAttributes.scriptS3BucketName, scriptKeyPrefix, scriptKey): _*
+              generateEnvironmentKVPairs(
+                runtimeAttributes.scriptS3BucketName,
+                scriptKeyPrefix,
+                scriptKey
+              ): _*
             )
             .resourceRequirements(resourceRequirements.asJava)
             .build()
@@ -599,67 +727,110 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
         .jobDefinition(definitionArn)
       // tagging activated : add to request
       if (tagResources.getOrElse(false)) {
-          // replace invalid characters in the tags
-          val invalidCharsPattern = "[^a-zA-Z0-9_.:/=+-@]+".r
-          val tags: Map[String,String] = Map(
-            "cromwell-workflow-name" -> invalidCharsPattern.replaceAllIn(workflowName,"_"), 
-            "cromwell-workflow-id" -> invalidCharsPattern.replaceAllIn(workflowId,"_"), 
-            "cromwell-task-id" -> invalidCharsPattern.replaceAllIn(taskId,"_"),
-            "cromwell-root-workflow-name" -> invalidCharsPattern.replaceAllIn(jobDescriptor.workflowDescriptor.rootWorkflow.name.toString,"_"),
-            "cromwell-root-workflow-id" -> invalidCharsPattern.replaceAllIn(jobDescriptor.workflowDescriptor.rootWorkflowId.toString,"_")
-            )
-          submitJobRequest = submitJobRequest.tags(tags.asJava).propagateTags(true)
+        // replace invalid characters in the tags
+        val invalidCharsPattern = "[^a-zA-Z0-9_.:/=+-@]+".r
+        val tags: Map[String, String] = Map(
+          "cromwell-workflow-name" -> invalidCharsPattern
+            .replaceAllIn(workflowName, "_"),
+          "cromwell-workflow-id" -> invalidCharsPattern
+            .replaceAllIn(workflowId, "_"),
+          "cromwell-task-id" -> invalidCharsPattern.replaceAllIn(taskId, "_"),
+          "cromwell-root-workflow-name" -> invalidCharsPattern.replaceAllIn(
+            jobDescriptor.workflowDescriptor.rootWorkflow.name.toString,
+            "_"
+          ),
+          "cromwell-root-workflow-id" -> invalidCharsPattern.replaceAllIn(
+            jobDescriptor.workflowDescriptor.rootWorkflowId.toString,
+            "_"
+          )
+        )
+        submitJobRequest =
+          submitJobRequest.tags(tags.asJava).propagateTags(true)
       }
       // submit
       val submit: F[SubmitJobResponse] =
-        async.delay(batchClient.submitJob(
+        async.delay(
+          batchClient.submitJob(
             submitJobRequest.build
-        ))
+          )
+        )
 
       ReaderT.liftF(
-        Stream.retry(submit, 0.millis, duration => duration.plus(duration), awsBatchAttributes.submitAttempts.value, {
-          // RegisterJobDefinition is eventually consistent, so it may not be there
-          case e: ClientException => e.statusCode() == 404
-          case _ => false
-        }).compile.last.map(_.get)) //if successful there is guaranteed to be a value emitted, hence we can .get this option
+        Stream
+          .retry(
+            submit,
+            0.millis,
+            duration => duration.plus(duration),
+            awsBatchAttributes.submitAttempts.value,
+            {
+              // RegisterJobDefinition is eventually consistent, so it may not be there
+              case e: ClientException => e.statusCode() == 404
+              case _                  => false
+            }
+          )
+          .compile
+          .last
+          .map(_.get)
+      ) // if successful there is guaranteed to be a value emitted, hence we can .get this option
     }
 
-    (findOrCreateDefinition[F]() product Kleisli.ask[F, AwsBatchAttributes]).flatMap((callClient _).tupled)
+    (findOrCreateDefinition[F]() product Kleisli.ask[F, AwsBatchAttributes])
+      .flatMap((callClient _).tupled)
   }
 
-
-  /**
-    * Performs an md5 digest the script, checks in s3 bucket for that script, if it's not already there then persists it.
+  /** Performs an md5 digest the script, checks in s3 bucket for that script, if
+    * it's not already there then persists it.
     *
-    * @param commandLine the command line script to be executed
-    * @param scriptS3BucketName the bucket that stores the scripts
-    * @return the name of the script that was found or created
+    * @param commandLine
+    *   the command line script to be executed
+    * @param scriptS3BucketName
+    *   the bucket that stores the scripts
+    * @return
+    *   the name of the script that was found or created
     */
-  private def findOrCreateS3Script(commandLine :String, scriptS3BucketName: String) :String = {
+  private def findOrCreateS3Script(
+      commandLine: String,
+      scriptS3BucketName: String
+  ): String = {
 
     val bucketName = scriptS3BucketName
     // this is md5 digest of the script contents ( == commandLine)
-    val key = MessageDigest.getInstance("MD5")
+    val key = MessageDigest
+      .getInstance("MD5")
       .digest(commandLine.getBytes())
       .foldLeft("")(_ + "%02x".format(_))
 
-    Log.debug(s"s3 object name for script is calculated to be s3://$bucketName/$scriptKeyPrefix$key")
+    Log.debug(
+      s"s3 object name for script is calculated to be s3://$bucketName/$scriptKeyPrefix$key"
+    )
 
-    try { //try and get the object
+    try { // try and get the object
 
-      s3Client.getObject( GetObjectRequest.builder().bucket(bucketName).key( scriptKeyPrefix + key).build )
-      s3Client.headObject(HeadObjectRequest.builder()
-        .bucket(bucketName)
-        .key( scriptKeyPrefix + key )
-        .build
-      ).eTag().equals(key) // as key is the md5 of script content, and script is small (<8mb) => key should be equal to eTag if the file exists.
+      s3Client.getObject(
+        GetObjectRequest
+          .builder()
+          .bucket(bucketName)
+          .key(scriptKeyPrefix + key)
+          .build
+      )
+      s3Client
+        .headObject(
+          HeadObjectRequest
+            .builder()
+            .bucket(bucketName)
+            .key(scriptKeyPrefix + key)
+            .build
+        )
+        .eTag()
+        .equals(key) // as key is the md5 of script content, and script is small (<8mb) => key should be equal to eTag if the file exists.
 
       // if there's no exception then the script already exists
       Log.debug(s"""Found script $bucketName/$scriptKeyPrefix$key""")
     } catch {
-      case _: NoSuchKeyException =>  //this happens if there is no object with that key in the bucket
-        val putRequest = PutObjectRequest.builder()
-          .bucket(bucketName) //remove the "s3://" prefix
+      case _: NoSuchKeyException => // this happens if there is no object with that key in the bucket
+        val putRequest = PutObjectRequest
+          .builder()
+          .bucket(bucketName) // remove the "s3://" prefix
           .key(scriptKeyPrefix + key)
           .build
 
@@ -670,25 +841,34 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
     key
   }
 
-  private def writeReconfiguredScriptForAudit( reconfiguredScript: String, bucketName: String, key: String) = {
-    val putObjectRequest = PutObjectRequest.builder().bucket(bucketName).key(key).build()
-    s3Client.putObject(putObjectRequest, RequestBody.fromString(reconfiguredScript))
+  private def writeReconfiguredScriptForAudit(
+      reconfiguredScript: String,
+      bucketName: String,
+      key: String
+  ) = {
+    val putObjectRequest =
+      PutObjectRequest.builder().bucket(bucketName).key(key).build()
+    s3Client.putObject(
+      putObjectRequest,
+      RequestBody.fromString(reconfiguredScript)
+    )
   }
 
   /** Creates a job definition in AWS Batch
     *
-    * @return Arn for newly created job definition
-    *
+    * @return
+    *   Arn for newly created job definition
     */
-  private def findOrCreateDefinition[F[_]]()
-                                          (implicit async: Async[F], timer: Timer[F]): Aws[F, String] = ReaderT { awsBatchAttributes =>
-
+  private def findOrCreateDefinition[F[_]]()(implicit
+      async: Async[F],
+      timer: Timer[F]
+  ): Aws[F, String] = ReaderT { awsBatchAttributes =>
     // this is a call back that is executed below by the async.recoverWithRetry(retry)
     val submit = async.delay({
 
       val commandStr = awsBatchAttributes.fileSystem match {
         case AWSBatchStorageSystems.s3 => reconfiguredScript
-        case _ => commandScript
+        case _                         => commandScript
       }
       val jobDefinitionContext = AwsBatchJobDefinitionContext(
         runtimeAttributes = runtimeAttributes,
@@ -705,67 +885,88 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
         efsMakeMD5 = efsMakeMD5,
         efsDelocalize = efsDelocalize,
         tagResources = tagResources
-        )
+      )
 
       val jobDefinitionBuilder = StandardAwsBatchJobDefinitionBuilder
       val jobDefinition = jobDefinitionBuilder.build(jobDefinitionContext)
 
+      // check if there is already a suitable definition based on the calculated job definition name
 
-      //check if there is already a suitable definition based on the calculated job definition name
+      Log.debug(
+        s"Checking for existence of job definition called: ${jobDefinition.name}"
+      )
 
-      Log.debug(s"Checking for existence of job definition called: ${jobDefinition.name}")
-
-      val describeJobDefinitionRequest = DescribeJobDefinitionsRequest.builder()
-        .jobDefinitionName( jobDefinition.name )
+      val describeJobDefinitionRequest = DescribeJobDefinitionsRequest
+        .builder()
+        .jobDefinitionName(jobDefinition.name)
         .status("ACTIVE")
         .build()
 
-      val describeJobDefinitionResponse = batchClient.describeJobDefinitions(describeJobDefinitionRequest)
+      val describeJobDefinitionResponse =
+        batchClient.describeJobDefinitions(describeJobDefinitionRequest)
 
-      if ( !describeJobDefinitionResponse.jobDefinitions.isEmpty ) {
-        //sort the definitions so that the latest revision is at the head
-        val existingDefinition = describeJobDefinitionResponse.jobDefinitions().asScala.toList.sortWith(_.revision > _.revision).head
+      if (!describeJobDefinitionResponse.jobDefinitions.isEmpty) {
+        // sort the definitions so that the latest revision is at the head
+        val existingDefinition = describeJobDefinitionResponse
+          .jobDefinitions()
+          .asScala
+          .toList
+          .sortWith(_.revision > _.revision)
+          .head
 
-        //TODO test this
-        //if (existingDefinition.containerProperties().memory() != null || existingDefinition.containerProperties().vcpus() != null) {
+        // TODO test this
+        // if (existingDefinition.containerProperties().memory() != null || existingDefinition.containerProperties().vcpus() != null) {
         //  Log.warn("the job definition '{}' has deprecated configuration for memory and vCPU and will be replaced", existingDefinition.jobDefinitionName())
         //  registerJobDefinition(jobDefinition, jobDefinitionContext).jobDefinitionArn()
-        //} else {
+        // } else {
         existingDefinition.jobDefinitionArn()
-        //}
+        // }
       } else {
-        Log.debug(s"No job definition found. Creating job definition: ${jobDefinition.name}")
+        Log.debug(
+          s"No job definition found. Creating job definition: ${jobDefinition.name}"
+        )
 
-        val response: RegisterJobDefinitionResponse = registerJobDefinition(jobDefinition, jobDefinitionContext)
+        val response: RegisterJobDefinitionResponse =
+          registerJobDefinition(jobDefinition, jobDefinitionContext)
         response.jobDefinitionArn()
       }
     })
 
-
     // a function to retry submissions, returns a higher kind parameterized on a String (where the String is an arn)
-    val retry: F[String] = Stream.retry(
-      fo = submit, //the value to attempt to get
-      delay = 0.millis, //how long to wait
-      nextDelay = _ * 2, //how long to back off after a failure
-      maxAttempts = awsBatchAttributes.createDefinitionAttempts.value, //how many times to try
-      retriable = { //a function to say if we should retry or not
-        // RegisterJobDefinition throws 404s every once in a while
-        case e: ClientException => e.statusCode() == 404 || e.statusCode() == 409
-        // a 409 means an eventual consistency collision has happened, most likely during a scatter.
-        // Just wait and retry as job definition names are canonical and if another thread succeeds in making one then
-        // that will be used and if there really isn't one, then the definition will be created.
-        case _ => false  //don't retry other cases
-      }
-    ).compile.last.map(_.get)
+    val retry: F[String] = Stream
+      .retry(
+        fo = submit, // the value to attempt to get
+        delay = 0.millis, // how long to wait
+        nextDelay = _ * 2, // how long to back off after a failure
+        maxAttempts =
+          awsBatchAttributes.createDefinitionAttempts.value, // how many times to try
+        retriable = { // a function to say if we should retry or not
+          // RegisterJobDefinition throws 404s every once in a while
+          case e: ClientException =>
+            e.statusCode() == 404 || e.statusCode() == 409
+          // a 409 means an eventual consistency collision has happened, most likely during a scatter.
+          // Just wait and retry as job definition names are canonical and if another thread succeeds in making one then
+          // that will be used and if there really isn't one, then the definition will be created.
+          case _ => false // don't retry other cases
+        }
+      )
+      .compile
+      .last
+      .map(_.get)
 
     // attempt to register the job definition
-    async.recoverWith(submit){
-      case e: ClientException if e.statusCode == 404 ||
-        e.statusCode == 409 || e.statusCode == 429  => retry  //probably worth trying again
+    async.recoverWith(submit) {
+      case e: ClientException
+          if e.statusCode == 404 ||
+            e.statusCode == 409 || e.statusCode == 429 =>
+        retry // probably worth trying again
     }
   }
 
-  def registerJobDefinition(jobDefinition: AwsBatchJobDefinition, jobDefinitionContext: AwsBatchJobDefinitionContext): RegisterJobDefinitionResponse = {
+  def registerJobDefinition(
+      jobDefinition: AwsBatchJobDefinition,
+      jobDefinitionContext: AwsBatchJobDefinitionContext
+  ): RegisterJobDefinitionResponse = {
     // See:
     //
     // http://aws-java-sdk-javadoc.s3-website-us-west-2.amazonaws.com/latest/software/amazon/awssdk/services/batch/model/RegisterJobDefinitionRequest.Builder.html
@@ -775,17 +976,19 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
       // See https://stackoverflow.com/questions/24349517/scala-method-named-type
       .`type`(JobDefinitionType.CONTAINER)
 
-    if (jobDefinitionContext.runtimeAttributes.awsBatchRetryAttempts != 0){
-      definitionRequest = definitionRequest.retryStrategy(jobDefinition.retryStrategy)
+    if (jobDefinitionContext.runtimeAttributes.awsBatchRetryAttempts != 0) {
+      definitionRequest =
+        definitionRequest.retryStrategy(jobDefinition.retryStrategy)
     }
     batchClient.registerJobDefinition(definitionRequest.build)
   }
 
   /** Gets the status of a job by its Id, converted to a RunStatus
     *
-    *  @param jobId Job ID as defined in AWS Batch
-    *  @return Current RunStatus
-    *
+    * @param jobId
+    *   Job ID as defined in AWS Batch
+    * @return
+    *   Current RunStatus
     */
   def status(jobId: String): Try[RunStatus] = for {
     statusString <- Try(detail(jobId).status)
@@ -793,34 +996,47 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
   } yield runStatus
 
   def detail(jobId: String): JobDetail = {
-    val describeJobsResponse = batchClient.describeJobs(DescribeJobsRequest.builder.jobs(jobId).build)
+    val describeJobsResponse =
+      batchClient.describeJobs(DescribeJobsRequest.builder.jobs(jobId).build)
 
-    val jobDetail = describeJobsResponse.jobs.asScala.headOption.
-      getOrElse(throw new RuntimeException(s"Expected a job Detail to be present from this request: $describeJobsResponse and this response: $describeJobsResponse "))
+    val jobDetail = describeJobsResponse.jobs.asScala.headOption.getOrElse(
+      throw new RuntimeException(
+        s"Expected a job Detail to be present from this request: $describeJobsResponse and this response: $describeJobsResponse "
+      )
+    )
 
     jobDetail
   }
 
   // code didn't get into the null block, so possibly not needed.
-  def rc(detail: JobDetail): Integer =  {
+  def rc(detail: JobDetail): Integer = {
     if (detail.container.exitCode == null) {
-        // if exitCode is not present, return failed ( exitCode == 127 for command not found)
-        Log.info("rc value missing. Setting to failed and sleeping for 30s...")
-        Thread.sleep(30000)
-        127
+      // if exitCode is not present, return failed ( exitCode == 127 for command not found)
+      Log.info("rc value missing. Setting to failed and sleeping for 30s...")
+      Thread.sleep(30000)
+      127
     } else {
-        Log.info("rc value found. Setting to '{}'",detail.container.exitCode.toString())
-        detail.container.exitCode
+      Log.info(
+        "rc value found. Setting to '{}'",
+        detail.container.exitCode.toString()
+      )
+      detail.container.exitCode
     }
   }
   def output(detail: JobDetail): String = {
-    val events: Seq[OutputLogEvent] = cloudWatchLogsClient.getLogEvents(GetLogEventsRequest.builder
-      // http://aws-java-sdk-javadoc.s3-website-us-west-2.amazonaws.com/latest/software/amazon/awssdk/services/batch/model/ContainerDetail.html#logStreamName--
-      .logGroupName("/aws/batch/job")
-      .logStreamName(detail.container.logStreamName)
-      .startFromHead(true)
-      .build).events.asScala.toList
-    val eventMessages = for ( event <- events ) yield event.message
+    val events: Seq[OutputLogEvent] = cloudWatchLogsClient
+      .getLogEvents(
+        GetLogEventsRequest.builder
+          // http://aws-java-sdk-javadoc.s3-website-us-west-2.amazonaws.com/latest/software/amazon/awssdk/services/batch/model/ContainerDetail.html#logStreamName--
+          .logGroupName("/aws/batch/job")
+          .logStreamName(detail.container.logStreamName)
+          .startFromHead(true)
+          .build
+      )
+      .events
+      .asScala
+      .toList
+    val eventMessages = for (event <- events) yield event.message
     eventMessages mkString "\n"
   }
 
@@ -829,12 +1045,17 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
      * Using Terminate here because it will work on jobs at any stage of their lifecycle whereas cancel will only work
      * on jobs that are not yet at the STARTING or RUNNING phase
      */
-    batchClient.terminateJob(TerminateJobRequest.builder.jobId(jobId).reason("cromwell abort called").build())
+    batchClient.terminateJob(
+      TerminateJobRequest.builder
+        .jobId(jobId)
+        .reason("cromwell abort called")
+        .build()
+    )
   }
 
-  /**
-    * Generate a `String` describing the instance. Mainly for debugging
-    * @return a description of the instance
+  /** Generate a `String` describing the instance. Mainly for debugging
+    * @return
+    *   a description of the instance
     */
   override def toString: String = {
     new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
@@ -842,7 +1063,9 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
       .append("runtimeAttributes", runtimeAttributes)
       .append("commandLine", commandLine)
       .append("commandScript", commandScript)
-      .append("dockerRc", dockerRc).append("dockerStderr", dockerStderr).append("dockerStdout", dockerStdout)
+      .append("dockerRc", dockerRc)
+      .append("dockerStderr", dockerStderr)
+      .append("dockerStdout", dockerStdout)
       .append("inputs", inputs)
       .append("outputs", outputs)
       .append("jobPaths", jobPaths)

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchGlobFunctions.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchGlobFunctions.scala
@@ -30,7 +30,6 @@
  */
 package cromwell.backend.impl.aws.io
 
-
 import wom.values._
 import cromwell.backend.io._
 import cromwell.backend.standard._
@@ -38,51 +37,65 @@ import scala.concurrent.Future
 import java.nio.file.Paths
 import cromwell.core.path.DefaultPathBuilder
 
-
 trait AwsBatchGlobFunctions extends GlobFunctions {
-    
+
   def standardParams: StandardExpressionFunctionsParams
 
-  
-
-  /**
-    * Returns a list of path from the glob.
+  /** Returns a list of path from the glob.
     *
     * The paths are read from a list file based on the pattern.
     *
-    * @param pattern The pattern of the glob. This is the same "glob" passed to globPath().
-    * @return The paths that match the pattern.
+    * @param pattern
+    *   The pattern of the glob. This is the same "glob" passed to globPath().
+    * @return
+    *   The paths that match the pattern.
     */
   override def glob(pattern: String): Future[Seq[String]] = {
     // get access to globName()
     import GlobFunctions._
-    
-    // GOAL : 
-    //  - get config (backend / runtime / ...) here to evaluate if efsMntPoint is set & if efs delocalization is set. 
-    //  - according to those values : write the pattern as s3:// or as local path. 
+
+    // GOAL :
+    //  - get config (backend / runtime / ...) here to evaluate if efsMntPoint is set & if efs delocalization is set.
+    //  - according to those values : write the pattern as s3:// or as local path.
     //  - get the wf id from the config settings.
 
-    // this function reads in the globfile and locates globbed files : "local" or NIO access is needed to the files. 
+    // this function reads in the globfile and locates globbed files : "local" or NIO access is needed to the files.
     // for now : hard coded as local at mount point /mnt/efs.
     val wfid_regex = ".{8}-.{4}-.{4}-.{4}-.{12}".r
-    val wfid = callContext.root.toString.split("/").toList.filter(element => wfid_regex.pattern.matcher(element).matches()).lastOption.getOrElse("")
+    val wfid = callContext.root.toString
+      .split("/")
+      .toList
+      .filter(element => wfid_regex.pattern.matcher(element).matches())
+      .lastOption
+      .getOrElse("")
     val globPatternName = globName(s"${pattern}-${wfid}")
-    val globbedDir = Paths.get(pattern).getParent.toString
+    var globbedDirPath =
+      Paths.get(pattern).getParent()
+    while (globbedDirPath.toString().contains("*")) {
+      globbedDirPath = globbedDirPath.getParent()
+    }
+    val globbedDir: String = globbedDirPath.toString()
     val listFilePath = if (pattern.startsWith("/mnt/efs/")) {
-        DefaultPathBuilder.get(globbedDir + "/." + globPatternName + ".list")
+      DefaultPathBuilder.get(globbedDir + "/." + globPatternName + ".list")
     } else {
-        callContext.root.resolve(s"${globbedDir}/.${globPatternName}.list".stripPrefix("/"))
+      callContext.root.resolve(
+        s"${globbedDir}/.${globPatternName}.list".stripPrefix("/")
+      )
     }
     asyncIo.readLinesAsync(listFilePath.toRealPath()) map { lines =>
       lines.toList map { fileName =>
         // again : this should be config based...
         if (pattern.startsWith("/mnt/efs/")) {
-            s"${globbedDir}/.${globPatternName}/${fileName}"
+          s"${globbedDir}/.${globPatternName}/${fileName}"
         } else {
-            callContext.root.resolve(s"${globbedDir}/.${globPatternName}/${fileName}".stripPrefix("/")).pathAsString
+          callContext.root
+            .resolve(
+              s"${globbedDir}/.${globPatternName}/${fileName}".stripPrefix("/")
+            )
+            .pathAsString
         }
       }
     }
   }
-  
+
 }


### PR DESCRIPTION
When globbing an output with multiple asterisks (e.g. Array[File] model_files = glob("models/\*/\*")), the output isn't correctly calculated (one asterisk remains in the s3 path).
Therefor this change will keep going up one level of the path to glob until all asterisks are gone.