### PR TITLE
AWS Batch - add support for custom log group name and additional tags

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -153,8 +153,8 @@ trait AwsBatchJobDefinitionBuilder {
       ).toList
     }
 
-    def buildName(imageName: String, packedCommand: String, volumes: List[Volume], mountPoints: List[MountPoint], env: Seq[KeyValuePair], ulimits: List[Ulimit], efsDelocalize: Boolean, efsMakeMD5: Boolean, tagResources: Boolean): String = {
-      s"$imageName:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints.map(_.toString).mkString(",")}:${env.map(_.toString).mkString(",")}:${ulimits.map(_.toString).mkString(",")}:${efsDelocalize.toString}:${efsMakeMD5.toString}:${tagResources.toString}"
+    def buildName(imageName: String, packedCommand: String, volumes: List[Volume], mountPoints: List[MountPoint], env: Seq[KeyValuePair], ulimits: List[Ulimit], efsDelocalize: Boolean, efsMakeMD5: Boolean, tagResources: Boolean, logGroupName: String): String = {
+      s"$imageName:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints.map(_.toString).mkString(",")}:${env.map(_.toString).mkString(",")}:${ulimits.map(_.toString).mkString(",")}:${efsDelocalize.toString}:${efsMakeMD5.toString}:${tagResources.toString}:$logGroupName"
     }
 
     val environment = List.empty[KeyValuePair]
@@ -165,6 +165,15 @@ trait AwsBatchJobDefinitionBuilder {
     val packedCommand = packCommand("/bin/bash", "-c", cmdName)
     val volumes =  buildVolumes( context.runtimeAttributes.disks, context.fsxMntPoint)
     val mountPoints = buildMountPoints( context.runtimeAttributes.disks, context.fsxMntPoint)
+    val logGroupName = context.runtimeAttributes.logGroupName
+    val logConfiguration = LogConfiguration.builder()
+      .logDriver("awslogs")
+      .options(
+        Map(
+          "awslogs-group" -> logGroupName
+        ).asJava
+      )
+      .build()
     val ulimits = buildUlimits( context.runtimeAttributes.ulimits)
     val efsDelocalize = context.runtimeAttributes.efsDelocalize
     val efsMakeMD5 = context.runtimeAttributes.efsMakeMD5
@@ -179,7 +188,8 @@ trait AwsBatchJobDefinitionBuilder {
       ulimits,
       efsDelocalize,
       efsMakeMD5,
-      tagResources
+      tagResources,
+      logGroupName
     )
 
     // To reuse job definition for gpu and gpu-runs, we will create a job definition that does not gpu requirements
@@ -191,6 +201,7 @@ trait AwsBatchJobDefinitionBuilder {
         ResourceRequirement.builder().`type`(ResourceType.VCPU).value(context.runtimeAttributes.cpu.##.toString).build(),
         ResourceRequirement.builder().`type`(ResourceType.MEMORY).value(context.runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString).build()
       )
+      .logConfiguration(logConfiguration)
       .volumes(volumes.asJava)
       .mountPoints(mountPoints.asJava)
       .environment(environment.asJava)

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -34,7 +34,7 @@ package cromwell.backend.impl.aws
 import scala.collection.mutable.ListBuffer
 import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.io.JobPaths
-import software.amazon.awssdk.services.batch.model.{ContainerProperties, EvaluateOnExit, Host, KeyValuePair, MountPoint, ResourceRequirement, ResourceType, RetryAction, RetryStrategy, Ulimit, Volume}
+import software.amazon.awssdk.services.batch.model.{ContainerProperties, EvaluateOnExit, Host, KeyValuePair, LogConfiguration, MountPoint, ResourceRequirement, ResourceType, RetryAction, RetryStrategy, Ulimit, Volume}
 import cromwell.backend.impl.aws.io.AwsBatchVolume
 
 import scala.jdk.CollectionConverters._

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
@@ -127,9 +127,9 @@ object AwsBatchRuntimeAttributes {
 
   private val MemoryDefaultValue = "2 GB"
 
-  private val logGroupKey = "logGroupName"
-  private val logGroupValidationInstance = new StringRuntimeAttributesValidation(logGroupKey)
-  private val LogGroupDefaultValue = WomString("/aws/batch/job")
+  private val logGroupNameKey = "logGroupName"
+  private val logGroupNameValidationInstance = new StringRuntimeAttributesValidation(logGroupNameKey)
+  private val LogGroupNameDefaultValue = WomString("/aws/batch/job")
 
   private val additionalTagsKey = "additionalTags"
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
@@ -56,6 +56,7 @@ import scala.jdk.CollectionConverters._
 
 /**
  * Attributes that are provided to the job at runtime
+ *
  * @param cpu number of vCPU
  * @param gpuCount number of gpu
  * @param zones the aws availability zones to run in
@@ -72,8 +73,10 @@ import scala.jdk.CollectionConverters._
  * @param awsBatchEvaluateOnExit Evaluate on exit strategy setting for AWS batch retry
  * @param ulimits ulimit values to be passed to the container
  * @param efsDelocalize should we delocalize efs files to s3
- * @param efsMakeMD5 should we make a sibling md5 file as part of the job 
+ * @param efsMakeMD5 should we make a sibling md5 file as part of the job
  * @param tagResources should we tag resources
+ * @param logGroupName the CloudWatch log group name to write logs to
+ * @param additionalTags a map of tags to add to the AWS Batch job submission
  */
 case class AwsBatchRuntimeAttributes(cpu: Int Refined Positive,
                                      gpuCount: Int,
@@ -91,6 +94,8 @@ case class AwsBatchRuntimeAttributes(cpu: Int Refined Positive,
                                      ulimits: Vector[Map[String, String]],
                                      efsDelocalize: Boolean,
                                      efsMakeMD5 : Boolean,
+                                     logGroupName: String,
+                                     additionalTags: Map[String, String],
                                      fileSystem: String= "s3",
                                      tagResources: Boolean = false)
 
@@ -121,6 +126,12 @@ object AwsBatchRuntimeAttributes {
   private val DisksDefaultValue = WomString(s"${AwsBatchWorkingDisk.Name}")
 
   private val MemoryDefaultValue = "2 GB"
+
+  private val logGroupKey = "logGroupName"
+  private val logGroupValidationInstance = new StringRuntimeAttributesValidation(logGroupKey)
+  private val LogGroupDefaultValue = WomString("/aws/batch/job")
+
+  private val additionalTagsKey = "additionalTags"
 
   val UlimitsKey = "ulimits"
   private val UlimitsDefaultValue = WomArray(WomArrayType(WomMapType(WomStringType,WomStringType)), Vector(WomMap(Map.empty[WomValue, WomValue])))
@@ -159,6 +170,9 @@ object AwsBatchRuntimeAttributes {
 
   private def noAddressValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Boolean] = noAddressValidationInstance
     .withDefault(noAddressValidationInstance.configDefaultWomValue(runtimeConfig) getOrElse NoAddressDefaultValue)
+
+  private def logGroupNameValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[String] = logGroupNameValidationInstance
+    .withDefault(logGroupNameValidationInstance.configDefaultWomValue(runtimeConfig) getOrElse LogGroupNameDefaultValue)
 
   private def scriptS3BucketNameValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[String] = {
     ScriptS3BucketNameValidation(scriptS3BucketKey).withDefault(ScriptS3BucketNameValidation(scriptS3BucketKey)
@@ -205,7 +219,7 @@ object AwsBatchRuntimeAttributes {
     // get the runtime attributes out of full config
     val rtc: Config = configuration.runtimeConfig match {
         case Some(x) => x
-        case None => 
+        case None =>
             Log.error("aws-batch default runtime attributes not found.")
             throw new RuntimeException("Default runtime attributes not found in config. This should always be present for AWS ! ")
     }
@@ -215,7 +229,7 @@ object AwsBatchRuntimeAttributes {
     val rtc_disks = try {
         rtc.getAnyRef(AwsBatchRuntimeAttributes.DisksKey).asInstanceOf[String] // just to prevent complaints about var/val
     } catch {
-        case _: ConfigException.Missing => 
+        case _: ConfigException.Missing =>
            "local-disk"
     }
     // combine and remove empty values and remove empty values
@@ -238,6 +252,7 @@ object AwsBatchRuntimeAttributes {
                         dockerValidation,
                         queueArnValidation(runtimeConfig),
                         scriptS3BucketNameValidation(runtimeConfig),
+                        logGroupNameValidation(runtimeConfig),
                         awsBatchRetryAttemptsValidation(runtimeConfig),
                         awsBatchEvaluateOnExitValidation(runtimeConfig),
                         ulimitsValidation(runtimeConfig),
@@ -256,6 +271,7 @@ object AwsBatchRuntimeAttributes {
       noAddressValidation(runtimeConfig),
       dockerValidation,
       queueArnValidation(runtimeConfig),
+      logGroupNameValidation(runtimeConfig),
       awsBatchRetryAttemptsValidation(runtimeConfig),
       awsBatchEvaluateOnExitValidation(runtimeConfig),
       ulimitsValidation(runtimeConfig),
@@ -286,6 +302,14 @@ object AwsBatchRuntimeAttributes {
        case AWSBatchStorageSystems.s3 => RuntimeAttributesValidation.extract(scriptS3BucketNameValidation(runtimeAttrsConfig) , validatedRuntimeAttributes)
        case _ => ""
     }
+    val logGroupName: String = RuntimeAttributesValidation.extract(logGroupNameValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
+    val additionalTags: Map[String, String] = runtimeAttrsConfig.collect {
+      case config if config.hasPath(additionalTagsKey) =>
+        config.getObject(additionalTagsKey).entrySet().asScala
+          .map(e => e.getKey -> e.getValue.unwrapped().toString)
+          .toMap
+    }.getOrElse(Map.empty[String, String])
+
     val awsBatchRetryAttempts: Int = RuntimeAttributesValidation.extract(awsBatchRetryAttemptsValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
     val awsBatchEvaluateOnExit: Vector[Map[String, String]] = RuntimeAttributesValidation.extract(awsBatchEvaluateOnExitValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
 
@@ -310,6 +334,8 @@ object AwsBatchRuntimeAttributes {
       ulimits,
       efsDelocalize,
       efsMakeMD5,
+      logGroupName,
+      additionalTags,
       fileSystem,
       tagResources
     )
@@ -642,7 +668,7 @@ object AwsBatchefsDelocalizeValidation {
 }
 
 class AwsBatchefsDelocalizeValidation(key: String) extends BooleanRuntimeAttributesValidation(key) {
-  
+
   override protected def missingValueMessage: String = s"Expecting $key runtime attribute to be an Boolean"
 }
 
@@ -651,7 +677,7 @@ object AwsBatchefsMakeMD5Validation {
 }
 
 class AwsBatchefsMakeMD5Validation(key: String) extends BooleanRuntimeAttributesValidation(key) {
-  
+
   override protected def missingValueMessage: String = s"Expecting $key runtime attribute to be an Boolean"
 }
 
@@ -660,9 +686,9 @@ object AwsBatchtagResourcesValidation {
 }
 
 class AwsBatchtagResourcesValidation(key: String) extends BooleanRuntimeAttributesValidation(key) {
-  
+
   override protected def missingValueMessage: String = s"Expecting $key runtime attribute to be a Boolean"
-}   
+}
 
 object UlimitsValidation
     extends RuntimeAttributesValidation[Vector[Map[String, String]]] {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -127,7 +127,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       efsDelocalize = false,
       efsMakeMD5 = false,
       fileSystem = "s3",
-      logsGroup = "/aws/batch/job",
+      logGroupName = "/aws/batch/job",
       additionalTags = Map("tag" -> "value")
   )
 

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -126,7 +126,10 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       ulimits = Vector(Map.empty[String, String]),
       efsDelocalize = false,
       efsMakeMD5 = false,
-      fileSystem = "s3")
+      fileSystem = "s3",
+      logsGroup = "/aws/batch/job",
+      additionalTags = Map("tag" -> "value")
+  )
 
   val batchJobDefintion = AwsBatchJobDefinitionContext(
     runtimeAttributes = runtimeAttributes,

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
@@ -58,8 +58,10 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     )))
   }
 
-  val expectedDefaults = new AwsBatchRuntimeAttributes(refineMV[Positive](1), 0, Vector("us-east-1a", "us-east-1b"),
-
+  val expectedDefaults = new AwsBatchRuntimeAttributes(
+    refineMV[Positive](1),
+    0,
+    Vector("us-east-1a", "us-east-1b"),
     MemorySize(2, MemoryUnit.GB), Vector(AwsBatchWorkingDisk()),
     "ubuntu:latest",
     "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue",
@@ -71,7 +73,9 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     Vector(Map.empty[String, String]),
     Vector(Map.empty[String, String]),
     false,
-    false
+    false,
+    "/Cromwell/job/",
+    Map("tag1" -> "value1")
   )
 
   val expectedDefaultsLocalFS = new AwsBatchRuntimeAttributes(refineMV[Positive](1), 0, Vector("us-east-1a", "us-east-1b"),
@@ -88,6 +92,8 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     Vector(Map.empty[String, String]),
     false,
     false,
+    "/Cromwell/job/",
+    Map(),
     "local")
 
   "AwsBatchRuntimeAttributes" should {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
@@ -62,7 +62,7 @@ object AwsBatchTestConfig {
       |    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
       |    scriptBucketName: "my-bucket"
       |    awsBatchRetryAttempts: 1
-      |    logsGroup: "/Cromwell/job/"
+      |    logGroupName: "/Cromwell/job/"
       |    resourceTags {
       |       tag1: "value1"
       |    }
@@ -146,7 +146,7 @@ object AwsBatchTestConfigForLocalFS {
       |    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
       |    scriptBucketName: ""
       |    awsBatchRetryAttempts: 1
-      |    logsGroup: "/Cromwell/job/"
+      |    logGroupName: "/Cromwell/job/"
       |}
       |
       |""".stripMargin

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
@@ -62,6 +62,10 @@ object AwsBatchTestConfig {
       |    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
       |    scriptBucketName: "my-bucket"
       |    awsBatchRetryAttempts: 1
+      |    logsGroup: "/Cromwell/job/"
+      |    resourceTags {
+      |       tag1: "value1"
+      |    }
       |}
       |
       |""".stripMargin
@@ -142,6 +146,7 @@ object AwsBatchTestConfigForLocalFS {
       |    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
       |    scriptBucketName: ""
       |    awsBatchRetryAttempts: 1
+      |    logsGroup: "/Cromwell/job/"
       |}
       |
       |""".stripMargin


### PR DESCRIPTION
Add the `logGroupName` and `additionalTags` config option to the `default-runtime-attributes` section of the AWS Batch configuration.

This enables you to send the logs to a custom log group name and tag the jobs that Cromwell submits.

Sample usage:
```
default-runtime-attributes {
    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
    logGroupName: "/Cromwell/job/"
    additionalTags {
       projectid: "project1"
    }
}
```