### PR TITLE
Fix/efs caching

### DIFF
--- a/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
@@ -54,6 +54,10 @@ object DefaultIoCommand {
     override def commandDescription: String = s"DefaultIoExistsCommand file '$file'"
   }
 
+  case class DefaultIoExistsOrThrowCommand(override val file: Path) extends IoExistsOrThrowCommand(file) {
+    override def commandDescription: String = s"DefaultIoExistsOrThrowCommand file '$file'"
+  }
+  
   case class DefaultIoReadLinesCommand(override val file: Path) extends IoReadLinesCommand(file) {
     override def commandDescription: String = s"DefaultIoReadLinesCommand file '$file'"
   }

--- a/core/src/main/scala/cromwell/core/io/IoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommand.scala
@@ -183,6 +183,14 @@ abstract class IoExistsCommand(val file: Path) extends SingleFileIoCommand[Boole
 }
 
 /**
+  * Check whether a file exists but throw an exception if it doesn't
+  */
+abstract class IoExistsOrThrowCommand(val file: Path) extends SingleFileIoCommand[Boolean] {
+  override def toString = s"Throw error if ${file.pathAsString} does not exist"
+  override lazy val name = "exist"
+}
+
+/**
   * Return the lines of a file in a collection
   */
 abstract class IoReadLinesCommand(val file: Path) extends SingleFileIoCommand[Iterable[String]] {

--- a/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
@@ -21,6 +21,7 @@ abstract class PartialIoCommandBuilder {
   def hashCommand: PartialFunction[Path, Try[IoHashCommand]] = PartialFunction.empty
   def touchCommand: PartialFunction[Path, Try[IoTouchCommand]] = PartialFunction.empty
   def existsCommand: PartialFunction[Path, Try[IoExistsCommand]] = PartialFunction.empty
+  def existsOrThrowCommand: PartialFunction[Path, Try[IoExistsOrThrowCommand]] = PartialFunction.empty
   def isDirectoryCommand: PartialFunction[Path, Try[IoIsDirectoryCommand]] = PartialFunction.empty
   def readLinesCommand: PartialFunction[Path, Try[IoReadLinesCommand]] = PartialFunction.empty
 }
@@ -94,6 +95,9 @@ class IoCommandBuilder(partialBuilders: List[PartialIoCommandBuilder] = List.emp
   def existsCommand(file: Path): Try[IoExistsCommand] =
     buildOrDefault(_.existsCommand, file, DefaultIoExistsCommand(file))
 
+  def existsOrThrowCommand(file: Path): Try[IoExistsOrThrowCommand] =
+    buildOrDefault(_.existsOrThrowCommand, file, DefaultIoExistsOrThrowCommand(file))
+    
   def isDirectoryCommand(file: Path): Try[IoIsDirectoryCommand] =
     buildOrDefault(_.isDirectoryCommand, file, DefaultIoIsDirectoryCommand(file))
 

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -20,6 +20,7 @@ import net.ceedubs.ficus.readers.ValueReader
 
 import java.io._
 import java.nio.charset.StandardCharsets
+import java.nio.file.NoSuchFileException
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
@@ -78,6 +79,7 @@ class NioFlow(parallelism: Int,
       case hashCommand: IoHashCommand => hash(hashCommand) map hashCommand.success
       case touchCommand: IoTouchCommand => touch(touchCommand) map touchCommand.success
       case existsCommand: IoExistsCommand => exists(existsCommand) map existsCommand.success
+      case existsOrThrowCommand: IoExistsOrThrowCommand => existsOrThrow(existsOrThrowCommand) map existsOrThrowCommand.success
       case readLinesCommand: IoReadLinesCommand => readLines(readLinesCommand) map readLinesCommand.success
       case isDirectoryCommand: IoIsDirectoryCommand => isDirectory(isDirectoryCommand) map isDirectoryCommand.success
       case _ => IO.raiseError(new UnsupportedOperationException("Method not implemented"))
@@ -181,6 +183,13 @@ class NioFlow(parallelism: Int,
 
   private def exists(exists: IoExistsCommand) = IO {
     exists.file.exists
+  }
+
+  private def existsOrThrow(exists: IoExistsOrThrowCommand) = IO {
+    exists.file.exists match {
+      case false => throw new NoSuchFileException(exists.file.toString)
+      case true => true
+    }
   }
 
   private def readLines(exists: IoReadLinesCommand) = IO {

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchCommandBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchCommandBuilder.scala
@@ -90,6 +90,10 @@ private case object PartialS3BatchCommandBuilder extends PartialIoCommandBuilder
   override def existsCommand: PartialFunction[Path, Try[S3BatchExistsCommand]] = { case path: S3Path =>
     Try(S3BatchExistsCommand(path))
   }
+  
+  override def existsOrThrowCommand: PartialFunction[Path, Try[S3BatchExistsOrThrowCommand]] = { case path: S3Path =>
+    Try(S3BatchExistsOrThrowCommand(path))
+  }
 }
 
 /**

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchIoCommand.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchIoCommand.scala
@@ -38,12 +38,14 @@ import cromwell.core.io.{
   IoCopyCommand,
   IoDeleteCommand,
   IoExistsCommand,
+  IoExistsOrThrowCommand,
   IoHashCommand,
   IoSizeCommand,
   IoTouchCommand
 }
 
 import cromwell.filesystems.s3.S3Path
+import java.nio.file.NoSuchFileException
 
 /**
   * Io commands with S3 paths and some logic enabling batching of request.
@@ -139,6 +141,23 @@ case class S3BatchExistsCommand(override val file: S3Path)
     // If the object can't be found, don't fail the request but just return false as we were testing for existence
     error match {
       case _: NoSuchKeyException => Option(Left(false))
+      case _ => None
+    }
+  override def commandDescription: String = s"S3BatchExistsCommand file '$file'"
+}
+
+/**
+  * `IoCommand` to determine the existence of an object in S3, but throws execption if the object can't be found
+  * @param file the path to the object
+  */
+case class S3BatchExistsOrThrowCommand(override val file: S3Path)
+    extends IoExistsOrThrowCommand(file)
+    with S3BatchHeadCommand[Boolean] {
+  override def mapResponse(response: HeadObjectResponse): Boolean = true
+  override def onFailure(error: SdkException): Option[Left[Boolean, Nothing]] =
+    // If the object can't be found, fail the request and throw an exception
+    error match {
+      case _: NoSuchKeyException => throw new NoSuchFileException(file.toString)
       case _ => None
     }
   override def commandDescription: String = s"S3BatchExistsCommand file '$file'"

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -427,18 +427,17 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
            // need to make md5sum?
            val md5_cmd = if (efsMakeMD5.isDefined && efsMakeMD5.getOrElse(false)) {
                     Log.debug("Add cmd to create MD5 sibling.")
-                    // this does NOT regenerate the md5 in case the file is overwritten ! 
-                    // TODO : Add check for file age => recreate if md5 older than main file
+                    // generate MD5 if missing or if local file is newer than sibling md5
                     s"""
-                        |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]] ; then
+                        |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' -nt '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]]; then
                         |   # the glob list
                         |   md5sum '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' > '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || (echo 'Could not generate ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' && DELOCALIZATION_FAILED=1 );
                         |   # globbed files, using specified number of cpus for parallel processing.
-                        SAVEIFS="$$IFS"
-                        |IFS=$$'\n'
+                        |   SAVEIFS="$$IFS"
+                        |   IFS=$$'\n'
                         |   cat "${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}" | xargs -I% -P${runtimeAttributes.cpu.##.toString} bash -c "md5sum ${globDirectory}/% > ${globDirectory}/%.md5"
+                        |   IFS="$$SAVEIFS"
                         |fi
-                        |IFS="$$SAVEIFS"
                         |""".stripMargin
                 }
            // return combined result
@@ -461,7 +460,6 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
         Log.debug("output Data on working disk mount" + output.local.pathAsString)
         s"""_s3_delocalize_with_retry "$workDir/${output.local.pathAsString}" "${output.s3key}" """.stripMargin
 
-      // file(name (full path), s3key (delocalized path), local (file basename), mount (disk details))
       // files on EFS mounts are optionally delocalized.
       case output: AwsBatchFileOutput if efsMntPoint.isDefined && output.mount.mountPoint.pathAsString == efsMntPoint.get =>
         Log.debug("EFS output file detected: "+ output.s3key + s" / ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}")
@@ -478,9 +476,9 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
         // need to make md5sum?
         var md5_cmd = ""
         if (efsMakeMD5.isDefined && efsMakeMD5.getOrElse(false)) {
-            Log.debug("Add cmd to create MD5 sibling.")
+            Log.debug("Add cmd to create MD5 sibling if missing or outdated.")
             md5_cmd = s"""
-                            |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]] ; then
+                            |if [[ ! -f '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' -nt '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' ]]; then
                             |   md5sum '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}' > '${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' || (echo 'Could not generate ${output.mount.mountPoint.pathAsString}/${output.local.pathAsString}.md5' && DELOCALIZATION_FAILED=1 );
                             |fi
                             |""".stripMargin

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -42,6 +42,7 @@ import java.security.MessageDigest
 import org.apache.commons.lang3.builder.{ToStringBuilder, ToStringStyle}
 import org.slf4j.{Logger, LoggerFactory}
 import wdl4s.parser.MemoryUnit
+import wom.format.MemorySize
 
 /**
   * Responsible for the creation of the job definition.
@@ -164,8 +165,8 @@ trait AwsBatchJobDefinitionBuilder {
       efsMakeMD5: Boolean,
       tagResources: Boolean,
       logGroupName: String,
-      sharedMemorySize: Int): String = {
-        s"$imageName:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints.map(_.toString).mkString(",")}:${env.map(_.toString).mkString(",")}:${ulimits.map(_.toString).mkString(",")}:${efsDelocalize.toString}:${efsMakeMD5.toString}:${tagResources.toString}:$logGroupName"
+      sharedMemorySize: MemorySize): String = {
+        s"$imageName:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints.map(_.toString).mkString(",")}:${env.map(_.toString).mkString(",")}:${ulimits.map(_.toString).mkString(",")}:${efsDelocalize.toString}:${efsMakeMD5.toString}:${tagResources.toString}:$logGroupName:${sharedMemorySize.to(MemoryUnit.MB).amount.toInt}"
       }
 
     val environment = List.empty[KeyValuePair]
@@ -201,9 +202,8 @@ trait AwsBatchJobDefinitionBuilder {
       efsMakeMD5,
       tagResources,
       logGroupName,
-      context.runtimeAttributes.sharedMemorySize.value
+      context.runtimeAttributes.sharedMemorySize
     )
-
     // To reuse job definition for gpu and gpu-runs, we will create a job definition that does not gpu requirements
     // since aws batch does not allow you to set gpu as 0 when you dont need it. you will always need cpu and memory
     (ContainerProperties.builder()
@@ -219,8 +219,8 @@ trait AwsBatchJobDefinitionBuilder {
       .environment(environment.asJava)
       .ulimits(ulimits.asJava)
       .linuxParameters(
-        LinuxParameters.builder().sharedMemorySize(context.runtimeAttributes.sharedMemorySize.##).build()
-      ),
+      LinuxParameters.builder().sharedMemorySize(context.runtimeAttributes.sharedMemorySize.to(MemoryUnit.MB).amount.toInt).build() // Convert MemorySize to MB
+    ),
      containerPropsName)
   }
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/callcaching/AwsBatchBackendFileHashingActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/callcaching/AwsBatchBackendFileHashingActor.scala
@@ -39,10 +39,12 @@ import cromwell.core.io.DefaultIoCommandBuilder
 import scala.util.Try
 import cromwell.backend.standard.callcaching.StandardFileHashingActor.SingleFileHashRequest
 import cromwell.core.path.DefaultPathBuilder
+import org.slf4j.{Logger, LoggerFactory}
 
 class AwsBatchBackendFileHashingActor(standardParams: StandardFileHashingActorParams)
     extends StandardFileHashingActor(standardParams) {
 
+  val Log: Logger = LoggerFactory.getLogger(StandardFileHashingActor.getClass)
   override val ioCommandBuilder = BackendInitializationData
     .as[AwsBatchBackendInitializationData](standardParams.backendInitializationDataOption)
     .configuration
@@ -55,21 +57,32 @@ class AwsBatchBackendFileHashingActor(standardParams: StandardFileHashingActorPa
   val aws_config = BackendInitializationData.as[AwsBatchBackendInitializationData](standardParams.backendInitializationDataOption).configuration
   
   // custom strategy to handle efs (local) files, in case sibling-md5 file is present. 
+  //  if valid md5 is found : return the hash
+  //  if no md5 is found : return None (pass request to parent hashing actor)
+  //  if outdated md5 is found : return invalid string (assume file has been altered after md5 creation)
+  //  if file is missing : return invalid string
   override def customHashStrategy(fileRequest: SingleFileHashRequest): Option[Try[String]] = {
     val file = DefaultPathBuilder.get(fileRequest.file.valueString)
     if (aws_config.efsMntPoint.isDefined && file.toString.startsWith(aws_config.efsMntPoint.getOrElse("--")) && aws_config.checkSiblingMd5.getOrElse(false)) {
             val md5 = file.sibling(s"${file.toString}.md5")
             // check existance of the file : 
             if (!file.exists) {
+                Log.debug(s"File Missing: ${file.toString}")
                 // if missing, cache hit is invalid; return invalid md5
                 Some("File Missing").map(str => Try(str))
             }
-            // check existence of the sibling file
-            else if (md5.exists) {
+            // check existence of the sibling file and make sure it's newer than main file
+            else if (md5.exists && md5.lastModifiedTime.isAfter(file.lastModifiedTime)) {
                 // read the file.
+                Log.debug("Found valid sibling file for " + file.toString)
                 val md5_value: Option[String] = Some(md5.contentAsString.split("\\s+")(0))
                 md5_value.map(str => Try(str))
+            } else if (md5.exists && md5.lastModifiedTime.isBefore(file.lastModifiedTime)) {
+                // sibling file is outdated, return invalid md5
+                Log.debug("Found outdated sibling file for " + file.toString)
+                Some("Checksum File Outdated").map(str => Try(str))
             } else {
+                Log.debug("Found no sibling file for " + file.toString)
                 // File present, but no sibling found, fall back to default.
                 None
             }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -110,7 +110,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
   val s3Outputs: Set[AwsBatchFileOutput] = Set(AwsBatchFileOutput("baa", "s3://bucket/somewhere/baa", DefaultPathBuilder.get("baa"), AwsBatchWorkingDisk()))
 
   val cpu: Int Refined Positive = 2
-  val sharedMemorySize: Int Refined Positive = 64
+  val sharedMemorySize: MemorySize = "64 MB"
 
   val runtimeAttributes: AwsBatchRuntimeAttributes = new AwsBatchRuntimeAttributes(
       cpu = cpu,


### PR DESCRIPTION
These are changes applied post-merging of upstream release 87

Fixes: 
- Caching on EFS filesystems created empty files when using "touch" to check existence. 
- Caching on EFS filesystems used outdated md5 files for updated source data. 
- changes in sharedMemorySize were not picked up due to recycling of jobDefinition. 

Docs: 
- Updated docs for sharedMemory
- Added additionalTags and LogGroup options
- corrected some example snippets 