### PR TITLE
Feature/Optional_Files

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -287,7 +287,6 @@ class EngineJobExecutionActor(replyTo: ActorRef,
         log.info(s"BT-322 {} cache hit copying nomatch: could not find a suitable cache hit.", jobTag)
         workflowLogger.debug(s"Could not copy a suitable cache hit for {$jobTag}. No copy attempts were made.")
       }
-
       runJob(data)
     case Event(hashes: CallCacheHashes, data: ResponsePendingData) =>
       addHashesAndStay(data, hashes)

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -258,7 +258,6 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   private def areAllFilesOptional(womType: WomType): Boolean = {
     def innerAreAllFileTypesInWomTypeOptional(womType: WomType): Boolean = womType match {
       case WomOptionalType(_: WomPrimitiveFileType) => 
-          println(s"cast ${womType} as optional (case 1)")
           true
       case _: WomPrimitiveFileType => 
           false

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -475,10 +475,8 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       case (unlistedDirectory: WomUnlistedDirectory, _) =>
         generateUnlistedDirectoryOutputs(unlistedDirectory)
       case (singleFile: WomSingleFile, isOptional) =>
-        jobLogger.debug(s" file output: ${singleFile.value} of type ${singleFile.womType} -- optional : $isOptional")
         generateAwsBatchSingleFileOutputs(singleFile, isOptional)
       case (globFile: WomGlobFile, _) => 
-        jobLogger.info(s"${globFile} : is glob file")
         generateAwsBatchGlobFileOutputs(globFile)
     }
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -261,10 +261,8 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
           println(s"cast ${womType} as optional (case 1)")
           true
       case _: WomPrimitiveFileType => 
-          println(s"cast ${womType} as mandatory (case 2)")
           false
       case _: WomPrimitiveType =>
-          println(s"cast ${womType} as true (case 3)")
           true // WomPairTypes and WomCompositeTypes may have non-File components here which is fine.
       case WomArrayType(inner) => innerAreAllFileTypesInWomTypeOptional(inner)
       case WomMapType(_, inner) => innerAreAllFileTypesInWomTypeOptional(inner)
@@ -277,7 +275,6 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     // At the outermost level, primitives are never optional.
     womType match {
       case _: WomPrimitiveType => 
-          println(s"cast ${womType} as mandatory (case 4)")  
           false
       case _ => innerAreAllFileTypesInWomTypeOptional(womType)
     }

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchParameters.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchParameters.scala
@@ -47,7 +47,7 @@ sealed trait AwsBatchParameter {
 
 sealed trait AwsBatchInput extends AwsBatchParameter
 
-final case class AwsBatchFileInput(name: String, s3key: String, local: Path, mount: AwsBatchVolume)
+final case class AwsBatchFileInput(name: String, s3key: String, local: Path, mount: AwsBatchVolume, optional: Boolean)
     extends AwsBatchInput {
   def toKeyValuePair = KeyValuePair.builder.name(name).value(s3key).build
   def toStringString = (name, s3key)
@@ -59,7 +59,7 @@ final case class AwsBatchLiteralInput(name: String, value: String) extends AwsBa
   def toStringString = (name, value)
 }
 
-final case class AwsBatchFileOutput(name: String, s3key: String, local: Path, mount: AwsBatchVolume)
+final case class AwsBatchFileOutput(name: String, s3key: String, local: Path, mount: AwsBatchVolume, optional: Boolean)
     extends AwsBatchParameter {
   def toKeyValuePair = KeyValuePair.builder.name(name).value(s3key).build
   def toStringString = (name, s3key)

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/callcaching/AwsBatchBackendFileHashingActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/callcaching/AwsBatchBackendFileHashingActor.scala
@@ -151,7 +151,7 @@ class AwsBatchBackendFileHashingActor(standardParams: StandardFileHashingActorPa
         } else if (md5.exists && md5.lastModifiedTime.isBefore(file.lastModifiedTime)) {
             // sibling file is outdated, return invalid (random) string as md5
             Log.debug("Found outdated sibling file for " + file.toString)
-            Some(mRandom.alphanumeric.take(32).mkString.md5Sum).map(str => Try(str))
+            Some(Random.alphanumeric.take(32).mkString.md5Sum).map(str => Try(str))
         } else {
             // File present, but no sibling found, fall back to default.
             Log.debug("Found no sibling file for " + file.toString)

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/callcaching/AwsBatchBackendFileHashingActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/callcaching/AwsBatchBackendFileHashingActor.scala
@@ -90,7 +90,6 @@ class AwsBatchBackendFileHashingActor(standardParams: StandardFileHashingActorPa
     // At the outermost level, primitives are never optional.
     womType match {
       case _: WomPrimitiveType => 
-          println(s"cast ${womType} as mandatory (case 4)")  
           false
       case _ => innerAreAllFileTypesInWomTypeOptional(womType)
     }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
@@ -626,56 +626,64 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
           AwsBatchFileInput("stringToFileMap-0",
                             "s3://path/to/stringTofile1",
                             DefaultPathBuilder.get("path/to/stringTofile1"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
         batchInputs should contain(
           AwsBatchFileInput("stringToFileMap-1",
                             "s3://path/to/stringTofile2",
                             DefaultPathBuilder.get("path/to/stringTofile2"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
         batchInputs should contain(
           AwsBatchFileInput("fileToStringMap-0",
                             "s3://path/to/fileToString1",
                             DefaultPathBuilder.get("path/to/fileToString1"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
         batchInputs should contain(
           AwsBatchFileInput("fileToStringMap-1",
                             "s3://path/to/fileToString2",
                             DefaultPathBuilder.get("path/to/fileToString2"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
         batchInputs should contain(
           AwsBatchFileInput("fileToFileMap-0",
                             "s3://path/to/fileToFile1Key",
                             DefaultPathBuilder.get("path/to/fileToFile1Key"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
         batchInputs should contain(
           AwsBatchFileInput("fileToFileMap-1",
                             "s3://path/to/fileToFile1Value",
                             DefaultPathBuilder.get("path/to/fileToFile1Value"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
         batchInputs should contain(
           AwsBatchFileInput("fileToFileMap-2",
                             "s3://path/to/fileToFile2Key",
                             DefaultPathBuilder.get("path/to/fileToFile2Key"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
         batchInputs should contain(
           AwsBatchFileInput("fileToFileMap-3",
                             "s3://path/to/fileToFile2Value",
                             DefaultPathBuilder.get("path/to/fileToFile2Value"),
-                            workingDisk
+                            workingDisk,
+                            false
           )
         )
 
@@ -744,7 +752,7 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
     val batchInputs = backend.generateAwsBatchInputs(jobDescriptor)
     batchInputs should have size 1
     batchInputs should contain(
-      AwsBatchFileInput("in-0", "s3://blah/b/c.txt", DefaultPathBuilder.get("blah/b/c.txt"), workingDisk)
+      AwsBatchFileInput("in-0", "s3://blah/b/c.txt", DefaultPathBuilder.get("blah/b/c.txt"), workingDisk,false)
     )
     val outputs = backend.generateAwsBatchOutputs(jobDescriptor)
     outputs should have size 1
@@ -752,7 +760,8 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
       AwsBatchFileOutput("out",
                          s"s3://my-cromwell-workflows-bucket/file_passing/$workflowId/call-a/out",
                          DefaultPathBuilder.get("out"),
-                         workingDisk
+                         workingDisk,
+                         false
       )
     )
   }
@@ -781,7 +790,8 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
       AwsBatchFileInput("c6fd5c91-0",
                         "s3://some/path/file.txt",
                         DefaultPathBuilder.get("some/path/file.txt"),
-                        workingDisk
+                        workingDisk,
+                        false
       )
     )
     val outputs = backend.generateAwsBatchOutputs(jobDescriptor)
@@ -793,7 +803,7 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
     val batchInputsLocal = backend.generateAwsBatchInputs(jobDescriptorLocal)
     batchInputsLocal should have size 1
     batchInputsLocal should contain(
-      AwsBatchFileInput("c6fd5c91-0", "/some/path/file.txt", DefaultPathBuilder.get("some/path/file.txt"), workingDisk)
+      AwsBatchFileInput("c6fd5c91-0", "/some/path/file.txt", DefaultPathBuilder.get("some/path/file.txt"), workingDisk,false)
     )
     val outputsLocal = backendLocal.generateAwsBatchOutputs(jobDescriptorLocal)
     outputsLocal should have size 0
@@ -850,10 +860,10 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
         val batchInputs = testActorRef.underlyingActor.generateAwsBatchInputs(jobDescriptor)
         batchInputs should have size 2
         batchInputs should contain(
-          AwsBatchFileInput("fileArray-0", "s3://path/to/file1", DefaultPathBuilder.get("path/to/file1"), workingDisk)
+          AwsBatchFileInput("fileArray-0", "s3://path/to/file1", DefaultPathBuilder.get("path/to/file1"), workingDisk,false)
         )
         batchInputs should contain(
-          AwsBatchFileInput("fileArray-1", "s3://path/to/file2", DefaultPathBuilder.get("path/to/file2"), workingDisk)
+          AwsBatchFileInput("fileArray-1", "s3://path/to/file2", DefaultPathBuilder.get("path/to/file2"), workingDisk,false)
         )
       case Left(badness) => fail(badness.toList.mkString(", "))
     }
@@ -908,10 +918,10 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
         val batchInputs = testActorRef.underlyingActor.generateAwsBatchInputs(jobDescriptor)
         batchInputs should have size 2
         batchInputs should contain(
-          AwsBatchFileInput("file1-0", "s3://path/to/file1", DefaultPathBuilder.get("path/to/file1"), workingDisk)
+          AwsBatchFileInput("file1-0", "s3://path/to/file1", DefaultPathBuilder.get("path/to/file1"), workingDisk,false)
         )
         batchInputs should contain(
-          AwsBatchFileInput("file2-0", "s3://path/to/file2", DefaultPathBuilder.get("path/to/file2"), workingDisk)
+          AwsBatchFileInput("file2-0", "s3://path/to/file2", DefaultPathBuilder.get("path/to/file2"), workingDisk,false)
         )
 
       case Left(badness) => fail(badness.toList.mkString(", "))
@@ -923,27 +933,32 @@ class AwsBatchAsyncBackendJobExecutionActorSpec
       AwsBatchFileOutput("/cromwell_root/path/to/file1",
                          "s3://path/to/file1",
                          DefaultPathBuilder.get("/cromwell_root/path/to/file1"),
-                         workingDisk
+                         workingDisk,
+                         false
       ),
       AwsBatchFileOutput("/cromwell_root/path/to/file2",
                          "s3://path/to/file2",
                          DefaultPathBuilder.get("/cromwell_root/path/to/file2"),
-                         workingDisk
+                         workingDisk,
+                         false
       ),
       AwsBatchFileOutput("/cromwell_root/path/to/file3",
                          "s3://path/to/file3",
                          DefaultPathBuilder.get("/cromwell_root/path/to/file3"),
-                         workingDisk
+                         workingDisk,
+                         false
       ),
       AwsBatchFileOutput("/cromwell_root/path/to/file4",
                          "s3://path/to/file4",
                          DefaultPathBuilder.get("/cromwell_root/path/to/file4"),
-                         workingDisk
+                         workingDisk,
+                         false
       ),
       AwsBatchFileOutput("/cromwell_root/path/to/file5",
                          "s3://path/to/file5",
                          DefaultPathBuilder.get("/cromwell_root/path/to/file5"),
-                         workingDisk
+                         workingDisk,
+                         false
       )
     )
     val outputValues = Seq(

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -106,8 +106,8 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
   val jobDescriptor: BackendJobDescriptor = BackendJobDescriptor(workFlowDescriptor, jobKey, null, Map.empty, null, null, null)
 
   val jobPaths: AwsBatchJobPaths = AwsBatchJobPaths(workflowPaths, jobKey) 
-  val s3Inputs: Set[AwsBatchInput] = Set(AwsBatchFileInput("foo", "s3://bucket/foo", DefaultPathBuilder.get("foo"), AwsBatchWorkingDisk()))
-  val s3Outputs: Set[AwsBatchFileOutput] = Set(AwsBatchFileOutput("baa", "s3://bucket/somewhere/baa", DefaultPathBuilder.get("baa"), AwsBatchWorkingDisk()))
+  val s3Inputs: Set[AwsBatchInput] = Set(AwsBatchFileInput("foo", "s3://bucket/foo", DefaultPathBuilder.get("foo"), AwsBatchWorkingDisk(),false))
+  val s3Outputs: Set[AwsBatchFileOutput] = Set(AwsBatchFileOutput("baa", "s3://bucket/somewhere/baa", DefaultPathBuilder.get("baa"), AwsBatchWorkingDisk(), false))
 
   val cpu: Int Refined Positive = 2
   val sharedMemorySize: MemorySize = "64 MB"


### PR DESCRIPTION
As raised by **Peter Thomas** on slack : 

Added support for optional files in the AWS handling of (de)localization and caching:

- support for "File?"  
- support for "Array[File?]  in manual assignment
- support for "Array[File?]" in globbing

Tested for input and output of individual tasks and workflows:
- optional files are allowed to be missing during (de)localization on both S3 and EFS (mentioned to log) 
- optional files are considered valid in cache-hash calculation (if missing in original, and still missing => valid hit)  (silent)

_extra_ : minor optimization on hashing through EFS/MD5 files : if considered invalid, return a random string instead of the same message each time. This forces a cache-break. 

Note: Mixed types are not supported and cast to mandatory files: 
-  an array of [File_1, File_2] where _1 is optional and _2 is not, will be "non-optional" completely. 



For testing : see release 87.1-AWS in my own fork : https://github.com/geertvandeweyer/cromwell/releases/tag/87.1-AWS